### PR TITLE
feat: Optional shader preloading

### DIFF
--- a/src/shaders/index.js
+++ b/src/shaders/index.js
@@ -1,13 +1,11 @@
 const modules = import.meta.glob("./*.wgsl", { query: "?raw&inline" })
 
 const shaders = Object.fromEntries(
-  await Promise.all(
-    Object.entries(modules).map(async function ([path, module]) {
-      const { default: shader } = await module(),
-        name = path.replace("./", "")
-      return [name, shader]
-    })
-  )
+  Object.entries(modules).map(([path, module]) => {
+    const name = path.replace("./", "")
+    const fn = async () => (await module()).default
+    return [name, fn]
+  })
 )
 
 export default shaders

--- a/src/spark.js
+++ b/src/spark.js
@@ -316,11 +316,13 @@ class Spark {
   /**
    * Initialize the encoder by detecting available compression formats.
    * @param {GPUDevice} device - WebGPU device.
+   * @param {Object} options - Encoder options.
+   * @param {boolean} options.preload - Whether to preload all encoder pipelines (false by default).
    * @returns {Promise<void>} Resolves when initialization is complete.
    */
-  static async create(device, preload = false) {
+  static async create(device, options = {}) {
     const instance = new Spark()
-    await instance.#init(device, preload)
+    await instance.#init(device, options.preload ?? false)
     return instance
   }
 


### PR DESCRIPTION
Currently all pipelines are fetched and compiled. With this option, users can opt in to pipeline preloading:

```javascript
// preload
const spark = await Spark.create(device, {preload: true})

// lazy load
const spark = await Spark.create(device)
```

Maybe the ideal API would allow preloading specified pipelines, or the necessary pipelines for a specified list of features? But I think just the two options above could be an easy set of out-of-the-box defaults.