### PR TITLE
Automatic format selection not enabled by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It enables the use of standard image formats in WebGPU applications transcoding 
 
 > [Try the demo viewer](https://ludicon.com/sparkjs/viewer/)
 
---- 
+---
 
 ## Installation
 
@@ -89,8 +89,18 @@ Load an image and encode it to a compressed GPU texture.
   Configuration options for encoding:
 
   - **`format`** (`string`)
-    Desired block compression format. You can use any of the WebGPU format names or an abreviated form such as `"bc7"` or `"astc"`.
-    If omitted, the format is selected based on device capabilities choosing he highest quality format available.
+    Desired block compression format. The format can be specified in several different ways:
+
+      - A channel mask indicating the number of channels in your input: `"rgba"`, `"rgb"`, `"rg"` or `"r"`, the actual format is selected based on the device capabilities.
+
+      - An explicit WebGPU BC, ETC or ASTC format name, or an abbreviated form such as `"bc7"` or `"astc"`. Note, spark.js only supports 4x4 and LDR formats. By default 
+
+      - If you specify `auto`, the input texture is analyzed to detect the necessary number of channels. This has some overhead, it's always recommended to specify the format through one of the other methods. 
+    
+    Default: `rgb`.
+
+  - **`alpha`** 
+    Hint for the format selector. When an explicit channel mask is not provided, the channel mask is assumed to be `"rgb"`, providing 
 
   - **`mips`** or **`generateMipmaps`** (`boolean`)
     Whether to generate mipmaps. Currently mipmap generation uses a basic box filter in linear space. Default: `false`.
@@ -117,5 +127,4 @@ Load an image and encode it to a compressed GPU texture.
 - Use of the *Spark* shaders is covered under the <a href="https://ludicon.com/sparkjs/eula.html">*spark.js* EULA</a>. 
 
 See https://ludicon.com/sparkjs#Licensing for details on how to use *spark.js* in commercial projects. 
-
 

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -105,8 +105,6 @@
             fn main(@location(0) texCoord: vec2f) -> @location(0) vec4f {
                 var color = textureSampleLevel(t_diffuse, s_diffuse, texCoord, 0.0).xyz;
 
-                color = select(1.055 * pow(color, vec3f(1.0 / 2.4)) - 0.055, color * 12.92, color <= vec3f(0.0031308));
-
                 return vec4f(color, 1.0);
             }
         `;
@@ -152,7 +150,7 @@
         device.pushErrorScope('validation')
         device.pushErrorScope('internal')
 
-        texture = await spark.encodeTexture(textureUrl, { format: "rgb", srgb: true, mips: true, flipY: false });
+        texture = await spark.encodeTexture(textureUrl);
 
       } finally {
         const validationError = await device.popErrorScope();

--- a/src/spark.js
+++ b/src/spark.js
@@ -455,15 +455,43 @@ class Spark {
   }
 
   /**
-   * Load an image and transcode it to a compressed GPU texture.
-   * @param {GPUtexture | string | HTMLImageElement | HTMLCanvasElement | Blob | ArrayBuffer} source - Image input.
-   * @param {Object} options - Optional encoding options.
-   * @param {string} options.format - Desired block compression format ("rgb" by default).
-   * @param {boolean} options.generateMipmaps | options.mips - Whether to generate mipmaps (false by default).
-   * @param {boolean} options.srgb - Whether to store as sRGB. This also affects mipmap generation (false by default).
-   * @param {boolean} options.normal - Interpret the image as a normal map. Affects mipmap generation (false by default).
-   * @param {boolean} options.flipY - Flip image vertically.
-   * @returns {Promise<GPUTexture>} - A promise resolving to a GPU texture.
+   * Load an image and encode it to a compressed GPU texture.
+   *
+   * @param {GPUTexture | string | HTMLImageElement | HTMLCanvasElement | Blob | ArrayBuffer} source
+   *        The image to encode. Can be a GPUTexture, URL, DOM image/canvas, binary buffer, or Blob.
+   *
+   * @param {Object} [options] - Optional configuration for encoding.
+   *
+   * @param {string} [options.format="rgb"]
+   *        Desired block compression format. Can be specified in several ways:
+   *          - A channel mask indicating the number of channels in your input:
+   *            "rgba", "rgb", "rg", or "r". The actual GPU format is selected
+   *            based on device capabilities.
+   *          - An explicit WebGPU BC, ETC, or ASTC format name, or an abbreviated
+   *            form such as "bc7" or "astc". Note: only 4x4 LDR formats are supported.
+   *          - "auto" to analyze the input texture and detect the required channels.
+   *            This has some overhead, so specifying a format explicitly is preferred.
+   *
+   * @param {boolean} [options.alpha]
+   *        Hint for the automatic format selector. When no explicit format is provided,
+   *        the format is assumed to be "rgb". Supplying `alpha: true` will favor RGBA formats.
+   *
+   * @param {boolean} [options.mips=false] | [options.generateMipmaps=false]
+   *        Whether to generate mipmaps. Mipmaps are generated with a basic box filter
+   *        in linear space.
+   *
+   * @param {boolean} [options.srgb=false]
+   *        Whether to encode the image in an sRGB format. Also affects mipmap generation.
+   *        The `srgb` mode can also be inferred from the `format`.
+   *
+   * @param {boolean} [options.normal=false]
+   *        Interpret the image as a normal map. Affects automatic format selection,
+   *        favoring "bc5" and "eac-rg" formats.
+   *
+   * @param {boolean} [options.flipY=false]
+   *        Whether to vertically flip the image before encoding.
+   *
+   * @returns {Promise<GPUTexture>} A promise resolving to the encoded GPU texture.
    */
   async encodeTexture(source, options = {}) {
     assert(this.#device, "Spark is not initialized")

--- a/src/spark.js
+++ b/src/spark.js
@@ -955,6 +955,9 @@ class Spark {
         if (this.#isFormatSupported(SparkFormat.ASTC_4x4_RGB)) return SparkFormat.ASTC_4x4_RGB
         if (this.#isFormatSupported(SparkFormat.BC1_RGB)) return SparkFormat.BC1_RGB
         if (this.#isFormatSupported(SparkFormat.ETC2_RGB)) return SparkFormat.ETC2_RGB
+      } else if (options.normal) {
+        if (this.#isFormatSupported(SparkFormat.BC5_RG)) return SparkFormat.BC5_RG
+        if (this.#isFormatSupported(SparkFormat.EAC_RG)) return SparkFormat.EAC_RG
       } else {
         let channelCount
         if (image instanceof GPUTexture) {

--- a/src/spark.js
+++ b/src/spark.js
@@ -434,6 +434,8 @@ class Spark {
     // Only load the image if the format has not been specified by the user.
     if (options.format == undefined || options.format == "auto") {
       const image = source instanceof Image || source instanceof GPUTexture ? source : await loadImage(source)
+      
+      options.format = "auto"
       const format = await this.#getBestMatchingFormat(options, image)
 
       options.format = SparkFormatName[format]
@@ -456,7 +458,7 @@ class Spark {
    * Load an image and transcode it to a compressed GPU texture.
    * @param {GPUtexture | string | HTMLImageElement | HTMLCanvasElement | Blob | ArrayBuffer} source - Image input.
    * @param {Object} options - Optional encoding options.
-   * @param {string} options.format - Desired block compression format (auto-detect by default).
+   * @param {string} options.format - Desired block compression format ("rgb" by default).
    * @param {boolean} options.generateMipmaps | options.mips - Whether to generate mipmaps (false by default).
    * @param {boolean} options.srgb - Whether to store as sRGB. This also affects mipmap generation (false by default).
    * @param {boolean} options.normal - Interpret the image as a normal map. Affects mipmap generation (false by default).
@@ -912,7 +914,9 @@ class Spark {
   }
 
   async #getBestMatchingFormat(options, image) {
-    if (!options.format || options.format == "auto") {
+    if (options.format == undefined) {
+      options.format = "rgb"
+    } else if (options.format == "auto") {
       if (options.alpha) {
         if (this.#isFormatSupported(SparkFormat.BC7_RGBA)) return SparkFormat.BC7_RGBA
         if (this.#isFormatSupported(SparkFormat.ASTC_4x4_RGBA)) return SparkFormat.ASTC_4x4_RGBA


### PR DESCRIPTION
Automatic format selection is convenient when the application doesn't know what kind of texture is being loaded (for example, in a generic image viewer). However, it adds some overhead and should not be the default option when no format is specified. 

This PR sets the default format to "rgb". This selects the highest quality texture format and codec that can represent RGB colors. If your input image has an alpha channel you should provide `format: "rgba"` explicitly, or simply `alpha: true`.

Automatic format selection can still be enabled by setting the format to `"auto"`. This will analyze the input texture, determine the number of channels that are necessary to represent it, and chose the corresponding format and codec based on that.

The documentation has been updated to reflect this new behavior.