### PR TITLE
Add support for selective preloading of specific codecs.

### DIFF
--- a/examples/basic.html
+++ b/examples/basic.html
@@ -134,7 +134,7 @@
       const { device, context, canvasFormat } = await initWebGPU();
 
       // Create Spark instance.
-      const spark = await Spark.create(device)
+      const spark = await Spark.create(device, { preload: ["rgb"] })
 
       // Create vertex buffer
       const vertexBuffer = createVertexBuffer(device);


### PR DESCRIPTION
This PR extends the preload option to support not just a Boolean that preloads all codecs, but an array that specifies the codecs to be preloaded. The specification of the codecs is done using the same procedure used by the format option in the `encodeTexture` method. That is, you can use a WebGPU format name explicitly, for example, "bc7-rgba-unorm-srgb", or an abbreviated form like "bc7" or "rgb". The way the format is selected is by choosing the first format that contains the given the substring in the following list:

```
      "bc4-r",
      "eac-r",
      "bc5-rg",
      "eac-rg",
      "bc7-rgb",
      "bc1-rgb",
      "astc-rgb",
      "astc-4x4-rgb",
      "etc2-rgb",
      "bc7-rgba",
      "astc-rgba",
      "astc-4x4-rgba",
      "bc3-rgba",
      "etc2-rgba"
```

Additionally, this moves the `"loadPipeline"` time marker into the promise for more accurate results and reports also the name of the corresponding codec. This eliminates warnings when several pipelines are being loaded concurrently.

Finally, when a codec is not preloaded we can also start loading its pipeline as soon as we know the target format. This allows fetching and decoding the image concurrently.

I've updated the basic example to use selective preloading, although in this particular case the texture is encoded immediately after initialization, so the encoder still has to wait for the pipeline to finish loading.