### PR TITLE
Add support for concurrent image decode using createImageBitmap.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ Load an image and encode it to a compressed GPU texture.
 
 #### Parameters
 
-- **`source`** (`GPUtexture | string | HTMLImageElement | HTMLCanvasElement | Blob | ArrayBuffer`)  
-  The image to encode. Can be a GPUtexture, URL, DOM image/canvas, binary buffer, or blob.
+- **`source`** (`string | HTMLImageElement | ImageBitmap | GPUtexture`)  
+  The image to encode. Can be a GPUTexture, URL, DOM image or ImageBitmap.
 
 - **`options`** *(optional object)*
   Configuration options for encoding:

--- a/src/spark.js
+++ b/src/spark.js
@@ -253,17 +253,40 @@ function imageToByteArray(image) {
   return new Uint8Array(imageData.data.buffer)
 }
 
-function loadImage(url) {
-  return new Promise(function (resolve, reject) {
-    const image = new Image()
+function isSvgUrl(url) {
+  return /\.svg(?:$|\?)/i.test(url) || /^data:image\/svg\+xml[,;]/i.test(url)
+}
 
-    image.crossOrigin = "anonymous"
-    image.onload = function () {
-      resolve(image)
-    }
-    image.onerror = reject
-    image.src = url
+function loadImageElement(url) {
+  return new Promise((resolve, reject) => {
+    const img = new Image()
+    img.crossOrigin = "anonymous"
+    img.decoding = "async" // hint to decode off the main thread when possible
+    img.onload = () => resolve(img) // returns HTMLImageElement
+    img.onerror = reject
+    img.src = url
   })
+}
+
+async function loadImageBitmap(url, opts = {}) {
+  const res = await fetch(url, { mode: "cors" })
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`)
+  const blob = await res.blob()
+
+  // Note: createImageBitmap doesn't support image/svg+xml
+  return createImageBitmap(blob, {
+    imageOrientation: opts.flipY ? "flipY" : "none",
+    colorSpaceConversion: opts.colorSpaceConversion ?? "none"
+  })
+}
+
+function loadImage(url) {
+  if (isSvgUrl(url)) {
+    return loadImageElement(url)
+  } else {
+    // createImageBitmap appears to be slightly faster, but does not handle svg files.
+    return loadImageBitmap(url)
+  }
 }
 
 // This is prescribed by WebGPU.
@@ -426,15 +449,18 @@ class Spark {
    * Try to determine the best compression options automatically. Do not use this in production, this is
    * for the convenience of the spark.js image viewer only.
    *
-   * @param {string | HTMLImageElement | HTMLCanvasElement | Blob | ArrayBuffer | GPUTexture} source - Image input.
+   * @param {string | HTMLImageElement | ImageBitmap | GPUTexture} source - Image input.
    * @param {Object} options - Encoding options.
    * @returns {Object} - Recommended encoding options with an explicit encoding format.
    */
   async selectPreferredOptions(source, options = {}) {
     // Only load the image if the format has not been specified by the user.
     if (options.format == undefined || options.format == "auto") {
-      const image = source instanceof Image || source instanceof GPUTexture ? source : await loadImage(source)
-      
+      const image =
+        source instanceof Image || source instanceof ImageBitmap || source instanceof GPUTexture
+          ? source
+          : await loadImage(source)
+
       options.format = "auto"
       const format = await this.#getBestMatchingFormat(options, image)
 
@@ -457,8 +483,8 @@ class Spark {
   /**
    * Load an image and encode it to a compressed GPU texture.
    *
-   * @param {GPUTexture | string | HTMLImageElement | HTMLCanvasElement | Blob | ArrayBuffer} source
-   *        The image to encode. Can be a GPUTexture, URL, DOM image/canvas, binary buffer, or Blob.
+   * @param {string | HTMLImageElement | ImageBitmap | GPUTexture} source
+   *        The image to encode. Can be a GPUTexture, URL, DOM image or ImageBitmap.
    *
    * @param {Object} [options] - Optional configuration for encoding.
    *
@@ -496,7 +522,11 @@ class Spark {
   async encodeTexture(source, options = {}) {
     assert(this.#device, "Spark is not initialized")
 
-    const image = source instanceof Image || source instanceof GPUTexture ? source : await loadImage(source)
+    // @@ TODO: Add support for canvas elements, blobs and ArrayBuffers.
+    const image =
+      source instanceof Image || source instanceof ImageBitmap || source instanceof GPUTexture
+        ? source
+        : await loadImage(source)
     console.log("Loaded image", image)
 
     const format = await this.#getBestMatchingFormat(options, image)


### PR DESCRIPTION
Concurrent image decoding can be implemented in various ways. The simplest way would be to add `img.decoding = "async"` to the image element. This works just fine, but it appears the recommended approach is to use the  `createImageBimap` API. This appears to be slightly faster, but doesn't handle SVG files. 

To handle this I detect SVG urls and use the async Image element code path for SVG files, and the `createImageBitmap` code path otherwise.

Also, the documentation claimed that the input to encodeTexture could be HTMLCanvasElement, Blob or ArrayBuffer. This is not correct anymore, as we requires the existence of width and height attributes. HTMLCanvasElement could work with minor changes, but that needs to be tested, so for now I've corrected the documentation.