### PR TITLE
Add basic support for low quality codec selection.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ Load an image and encode it to a compressed GPU texture.
   - **`alpha`** 
     Hint for the automatic format selector. When no explicit format is provided, the format is assumed to be `"rgb"`. Supplying `alpha: true` will default to "rgba" instead.
 
+  - **`preferLowQuality`** 
+    Hint for the automatic format selector. When the input format is `"rgb"` it chooses 8 bit per block formats like `"bc1"`` or `"etc2"` instead of `"bc7"`` or `"astc"`.
+
   - **`mips`** or **`generateMipmaps`** (`boolean`)
     Whether to generate mipmaps. Mipmaps are generated with a basic box filter in linear space. Default: `false`.
 

--- a/src/spark.js
+++ b/src/spark.js
@@ -862,7 +862,7 @@ class Spark {
     if (preload) {
       let formatsToLoad
       if (Array.isArray(preload)) {
-        formatsToLoad = preload.map(n => this.#getPreferredFormat(n))
+        formatsToLoad = preload.map(n => this.#getPreferredFormat(n, false))
       } else {
         formatsToLoad = this.#supportedFormats
       }
@@ -992,7 +992,7 @@ class Spark {
     return this.#supportedFormats.has(format)
   }
 
-  #getPreferredFormat(format) {
+  #getPreferredFormat(format, preferLowQuality) {
     // First check if the format is an explicit format.
     const explicitFormat = SparkFormatMap[format]
     if (explicitFormat != undefined && this.#isFormatSupported(explicitFormat)) {
@@ -1000,7 +1000,25 @@ class Spark {
     }
 
     // Otherwise, try to match it based on the preferenceOrder. Formats are sorted by number of channel and quality.
-    const preferenceOrder = [
+    const preferenceOrder = preferLowQuality ?
+    [
+      "bc4-r",
+      "eac-r",
+      "bc5-rg",
+      "eac-rg",
+      "bc1-rgb",
+      "etc2-rgb",
+      "bc7-rgb",
+      "astc-rgb",
+      "astc-4x4-rgb",
+      "bc7-rgba",
+      "astc-rgba",
+      "astc-4x4-rgba",
+      "bc3-rgba",
+      "etc2-rgba"
+    ]
+    :    
+    [
       "bc4-r",
       "eac-r",
       "bc5-rg",
@@ -1078,7 +1096,7 @@ class Spark {
       throw new Error("No supported format found.")
     }
 
-    const format = this.#getPreferredFormat(options.format)
+    const format = this.#getPreferredFormat(options.format, options.preferLowQuality)
     if (format === undefined) {
       throw new Error(`Unsupported format: ${options.format}`)
     }


### PR DESCRIPTION
I'm not super happy with how this works, but this will have to do for now. Added a `preferLowQuality` to the `encodeTexture` `options` parameter, when set to true, the automatic selection will choose a lower quality format for RGB maps only. For example, on PC it will choose BC1 instead of BC7 and on mobile it will choose ETC2 instead of ASTC. This produces lower quality results, but reduces the size of the textures by half.

There are some problems with this approach:

- RG textures could potentially use a lower quality format, but these textures are often use for normal maps, which we know don't compress well with a single index plane. It would be nice to have more control and be able to use lower quality formats for RG textures also. This may make sense when the RG texture is used for other attributes that may be more correlated.

- Preloading is not aware of the `preferLowQuality` flag and will only preload the high quality codecs. Should we add a `preloadLowQuality` option? What if we want to preload both low and high quality codecs?

- This adds an `options` parameter to the gltf Spark plugin. It's not convenient having to specify the preference at the loader level. Ideally I'd like to specify preferences per model, but as far as I can tell, the loadAsync API does not allow passing user arguments to the plugins. My current solution is to have two loaders, which is ugly and seems inefficient.

- Is this the right naming? lowQuality/highQuality doesn't have correlation with the amount of effort/time spent by the encoder, but refers to the texture block size. Maybe this should be more explicit, for example, `preferLowQualityFormat` or `preferCompactFormat`.

In any case, I wanted to get this working for the upcoming demo, so I'm submitting it as is and will try to refine it later.