### PR TITLE
Add support for encoding offscreen canvas elements.

### DIFF
--- a/examples/canvas-gl.html
+++ b/examples/canvas-gl.html
@@ -1,0 +1,179 @@
+<!doctype html>
+<html>
+  <!-- prettier-ignore -->
+  <head>
+    <title>spark.js - Canvas source example (WebGL)</title>
+    <style>
+      body { margin: 0; font-family: sans-serif; }
+      canvas { display: block; }
+      #error {
+        position: absolute; top: 50%; left: 50%;
+        transform: translate(-50%, -50%);
+        padding: 2em; max-width: 600px; text-align: center;
+        background: rgba(255,255,255,0.95); border-radius: 10px;
+        box-shadow: 0 4px 6px rgba(0,0,0,0.1);
+      }
+    </style>
+  </head>
+
+  <body>
+    <canvas id="glCanvas"></canvas>
+    <script type="module">
+      import { SparkGL } from "@ludicon/spark.js"
+
+      function showError(message) {
+        const el = document.createElement("div")
+        el.id = "error"
+        el.innerHTML = `<h1>Error</h1><p>${message}</p>`
+        document.body.appendChild(el)
+      }
+
+      // Draw a procedural texture into an offscreen 2D canvas.
+      function createSourceCanvas(size = 512) {
+        const canvas = document.createElement("canvas")
+        canvas.width = size
+        canvas.height = size
+        const ctx = canvas.getContext("2d")
+
+        const gradient = ctx.createLinearGradient(0, 0, size, size)
+        gradient.addColorStop(0.0, "#ff3366")
+        gradient.addColorStop(0.5, "#ffaa22")
+        gradient.addColorStop(1.0, "#3366ff")
+        ctx.fillStyle = gradient
+        ctx.fillRect(0, 0, size, size)
+
+        ctx.strokeStyle = "rgba(255,255,255,0.6)"
+        ctx.lineWidth = 2
+        for (let i = 0; i < 12; i++) {
+          ctx.beginPath()
+          ctx.arc(size / 2, size / 2, 20 + i * 18, 0, Math.PI * 2)
+          ctx.stroke()
+        }
+
+        ctx.fillStyle = "white"
+        ctx.font = "bold 64px sans-serif"
+        ctx.textAlign = "center"
+        ctx.textBaseline = "middle"
+        ctx.fillText("spark.js", size / 2, size / 2)
+
+        return canvas
+      }
+
+      async function init() {
+        const canvas = document.getElementById("glCanvas")
+        const gl = canvas.getContext("webgl2", { antialias: false, depth: false, stencil: false })
+        if (!gl) { showError("WebGL2 is not supported."); return }
+
+        canvas.width = window.innerWidth
+        canvas.height = window.innerHeight
+
+        const spark = SparkGL.create(gl, { preload: ["rgb"], verbose: true })
+        if (spark.getSupportedFormats().length === 0) {
+          showError("No compressed texture formats supported on this device.")
+          return
+        }
+
+        // Use an HTMLCanvasElement as the encodeTexture source.
+        const source = createSourceCanvas(512)
+        let compressedTexture
+        try {
+          compressedTexture = await spark.encodeTexture(source, { srgb: true })
+        } catch (error) {
+          showError(`Failed to compress texture: ${error.message}`)
+          console.error(error)
+          return
+        }
+
+        const vertexShaderSource = `#version 300 es
+          in vec2 position;
+          in vec2 texCoord;
+          out vec2 vTexCoord;
+          uniform vec2 uCanvasSize;
+          uniform vec2 uTextureSize;
+          void main() {
+            vTexCoord = vec2(texCoord.x, 1.0 - texCoord.y);
+            float aspect = (uTextureSize.y * uCanvasSize.x) / (uCanvasSize.y * uTextureSize.x);
+            vec2 scale = vec2(min(1.0, 1.0 / aspect), min(1.0, aspect));
+            gl_Position = vec4(position * scale, 0.0, 1.0);
+          }`
+        const fragmentShaderSource = `#version 300 es
+          precision mediump float;
+          in vec2 vTexCoord;
+          out vec4 fragColor;
+          uniform sampler2D uTexture;
+          void main() { fragColor = texture(uTexture, vTexCoord); }`
+
+        function compileShader(type, src) {
+          const s = gl.createShader(type)
+          gl.shaderSource(s, src)
+          gl.compileShader(s)
+          if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) {
+            console.error(gl.getShaderInfoLog(s))
+            return null
+          }
+          return s
+        }
+
+        const program = gl.createProgram()
+        gl.attachShader(program, compileShader(gl.VERTEX_SHADER, vertexShaderSource))
+        gl.attachShader(program, compileShader(gl.FRAGMENT_SHADER, fragmentShaderSource))
+        gl.linkProgram(program)
+
+        // prettier-ignore
+        const positions = new Float32Array([
+          -1, -1, 0, 0,
+           1, -1, 1, 0,
+          -1,  1, 0, 1,
+           1,  1, 1, 1
+        ])
+        const vertexBuffer = gl.createBuffer()
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer)
+        gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW)
+
+        const positionLoc = gl.getAttribLocation(program, "position")
+        const texCoordLoc = gl.getAttribLocation(program, "texCoord")
+        const canvasSizeLoc = gl.getUniformLocation(program, "uCanvasSize")
+        const textureSizeLoc = gl.getUniformLocation(program, "uTextureSize")
+        const textureLoc = gl.getUniformLocation(program, "uTexture")
+
+        function render() {
+          gl.viewport(0, 0, canvas.width, canvas.height)
+          gl.clearColor(0.1, 0.1, 0.1, 1.0)
+          gl.clear(gl.COLOR_BUFFER_BIT)
+          gl.useProgram(program)
+
+          gl.activeTexture(gl.TEXTURE0)
+          gl.bindTexture(gl.TEXTURE_2D, compressedTexture.texture)
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+          gl.uniform1i(textureLoc, 0)
+          gl.uniform2f(canvasSizeLoc, canvas.width, canvas.height)
+          gl.uniform2f(textureSizeLoc, compressedTexture.width, compressedTexture.height)
+
+          gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer)
+          gl.enableVertexAttribArray(positionLoc)
+          gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 16, 0)
+          gl.enableVertexAttribArray(texCoordLoc)
+          gl.vertexAttribPointer(texCoordLoc, 2, gl.FLOAT, false, 16, 8)
+
+          gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4)
+        }
+
+        function resize() {
+          canvas.width = window.innerWidth
+          canvas.height = window.innerHeight
+          render()
+        }
+        window.addEventListener("resize", resize)
+        render()
+      }
+
+      init().catch(err => {
+        console.error(err)
+        showError(`Initialization failed: ${err.message}`)
+      })
+    </script>
+  </body>
+</html>

--- a/examples/canvas.html
+++ b/examples/canvas.html
@@ -1,0 +1,191 @@
+<!doctype html>
+<html>
+  <!-- prettier-ignore -->
+  <head>
+    <title>spark.js - Canvas source example (WebGPU)</title>
+    <style>
+      body { margin: 0; }
+      canvas { display: block; }
+    </style>
+  </head>
+
+  <body>
+    <script type="module">
+      import { Spark } from "@ludicon/spark.js"
+
+      const errorMessage = `
+          <div style="padding: 2em; font-family: sans-serif; max-width: 600px; margin: 5em auto; text-align: center;">
+            <h1>WebGPU Not Supported</h1>
+            <p>This demo requires a browser with WebGPU support.</p>
+          </div>
+        `
+
+      async function initWebGPU() {
+        if (!navigator.gpu) {
+          document.body.innerHTML = errorMessage
+          throw new Error("WebGPU not supported")
+        }
+        const adapter = await navigator.gpu.requestAdapter()
+        if (!adapter) {
+          document.body.innerHTML = errorMessage
+          throw new Error("No appropriate GPUAdapter found")
+        }
+        const requiredFeatures = Spark.getRequiredFeatures(adapter)
+        const device = await adapter.requestDevice({ requiredFeatures })
+
+        const canvas = document.createElement("canvas")
+        document.body.appendChild(canvas)
+        const context = canvas.getContext("webgpu")
+        const canvasFormat = navigator.gpu.getPreferredCanvasFormat()
+        context.configure({ device, format: canvasFormat, alphaMode: "opaque" })
+
+        return { device, context, canvasFormat }
+      }
+
+      // Draw a procedural texture into an offscreen 2D canvas.
+      function createSourceCanvas(size = 512) {
+        const canvas = document.createElement("canvas")
+        canvas.width = size
+        canvas.height = size
+        const ctx = canvas.getContext("2d")
+
+        const gradient = ctx.createLinearGradient(0, 0, size, size)
+        gradient.addColorStop(0.0, "#ff3366")
+        gradient.addColorStop(0.5, "#ffaa22")
+        gradient.addColorStop(1.0, "#3366ff")
+        ctx.fillStyle = gradient
+        ctx.fillRect(0, 0, size, size)
+
+        ctx.strokeStyle = "rgba(255,255,255,0.6)"
+        ctx.lineWidth = 2
+        for (let i = 0; i < 12; i++) {
+          ctx.beginPath()
+          ctx.arc(size / 2, size / 2, 20 + i * 18, 0, Math.PI * 2)
+          ctx.stroke()
+        }
+
+        ctx.fillStyle = "white"
+        ctx.font = "bold 64px sans-serif"
+        ctx.textAlign = "center"
+        ctx.textBaseline = "middle"
+        ctx.fillText("spark.js", size / 2, size / 2)
+
+        return canvas
+      }
+
+      const vertexShader = `
+        struct Uniforms { canvasWidth: f32, canvasHeight: f32, textureWidth: f32, textureHeight: f32 }
+        @group(0) @binding(0) var<uniform> uniforms: Uniforms;
+        struct VertexOutput { @builtin(position) position: vec4f, @location(0) texCoord: vec2f }
+        @vertex
+        fn main(@location(0) position: vec2f, @location(1) texCoord: vec2f) -> VertexOutput {
+          var output: VertexOutput;
+          let aspect = (uniforms.textureHeight * uniforms.canvasWidth) / (uniforms.canvasHeight * uniforms.textureWidth);
+          let scale = vec2f(min(1.0, 1.0 / aspect), max(-1.0, -aspect));
+          output.position = vec4f(position * scale, 0.0, 1.0);
+          output.texCoord = texCoord;
+          return output;
+        }`
+
+      const fragmentShader = `
+        @group(0) @binding(1) var t_diffuse: texture_2d<f32>;
+        @group(0) @binding(2) var s_diffuse: sampler;
+        @fragment
+        fn main(@location(0) texCoord: vec2f) -> @location(0) vec4f {
+          return vec4f(textureSampleLevel(t_diffuse, s_diffuse, texCoord, 0.0).xyz, 1.0);
+        }`
+
+      async function init() {
+        const { device, context, canvasFormat } = await initWebGPU()
+        const spark = await Spark.create(device, { preload: ["rgb"], verbose: true })
+
+        // Use an HTMLCanvasElement as the encodeTexture source.
+        const source = createSourceCanvas(512)
+        const texture = await spark.encodeTexture(source, { srgb: true })
+
+        // prettier-ignore
+        const vertices = new Float32Array([
+          -1.0, -1.0, 0.0, 0.0,
+           1.0, -1.0, 1.0, 0.0,
+          -1.0,  1.0, 0.0, 1.0,
+           1.0,  1.0, 1.0, 1.0
+        ])
+        const vertexBuffer = device.createBuffer({ size: vertices.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST })
+        device.queue.writeBuffer(vertexBuffer, 0, vertices)
+
+        const uniformBuffer = device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST })
+        const sampler = device.createSampler({ magFilter: "linear", minFilter: "linear" })
+
+        const bindGroupLayout = device.createBindGroupLayout({
+          entries: [
+            { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: "uniform" } },
+            { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
+            { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "filtering" } }
+          ]
+        })
+        const pipelineLayout = device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] })
+        const bindGroup = device.createBindGroup({
+          layout: bindGroupLayout,
+          entries: [
+            { binding: 0, resource: { buffer: uniformBuffer } },
+            { binding: 1, resource: texture.createView() },
+            { binding: 2, resource: sampler }
+          ]
+        })
+
+        const pipeline = device.createRenderPipeline({
+          layout: pipelineLayout,
+          vertex: {
+            module: device.createShaderModule({ code: vertexShader }),
+            entryPoint: "main",
+            buffers: [{ arrayStride: 16, attributes: [
+              { shaderLocation: 0, offset: 0, format: "float32x2" },
+              { shaderLocation: 1, offset: 8, format: "float32x2" }
+            ] }]
+          },
+          fragment: {
+            module: device.createShaderModule({ code: fragmentShader }),
+            entryPoint: "main",
+            targets: [{ format: canvasFormat }]
+          },
+          primitive: { topology: "triangle-strip", stripIndexFormat: "uint32" }
+        })
+
+        function resizeCanvas() {
+          const displayWidth = window.innerWidth
+          const displayHeight = window.innerHeight
+          const canvas = document.querySelector("canvas")
+          if (canvas.width !== displayWidth || canvas.height !== displayHeight) {
+            canvas.width = displayWidth
+            canvas.height = displayHeight
+            device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([displayWidth, displayHeight, texture.width, texture.height]))
+          }
+        }
+        window.addEventListener("resize", resizeCanvas)
+        resizeCanvas()
+
+        function render() {
+          const commandEncoder = device.createCommandEncoder()
+          const renderPass = commandEncoder.beginRenderPass({
+            colorAttachments: [{
+              view: context.getCurrentTexture().createView(),
+              clearValue: { r: 0, g: 0, b: 0, a: 0 },
+              loadOp: "clear",
+              storeOp: "store"
+            }]
+          })
+          renderPass.setPipeline(pipeline)
+          renderPass.setBindGroup(0, bindGroup)
+          renderPass.setVertexBuffer(0, vertexBuffer)
+          renderPass.draw(4, 1, 0, 0)
+          renderPass.end()
+          device.queue.submit([commandEncoder.finish()])
+          requestAnimationFrame(render)
+        }
+        render()
+      }
+
+      init().catch(err => console.error("Error:", err))
+    </script>
+  </body>
+</html>

--- a/examples/index.html
+++ b/examples/index.html
@@ -18,6 +18,7 @@
       <li><a href="basic.html">Basic example</a></li>
       <li><a href="mipmaps.html">Mipmapping example</a></li>
       <li><a href="svg.html">SVG example</a></li>
+      <li><a href="canvas.html">Canvas source example</a></li>
       <li><a href="realtime.html">Realtime procedural texture</a></li>
       <li><a href="three-basic.html">Basic example using three.js</a></li>
       <li><a href="three-gltf.html">GLTF example using three.js</a></li>
@@ -25,6 +26,7 @@
     <h1>WebGL Examples</h1>
     <ul id="examples">
       <li><a href="basic-gl.html">Basic example</a></li>
+      <li><a href="canvas-gl.html">Canvas source example</a></li>
       <li><a href="mipmaps-gl.html">Mipmapping example</a></li>
       <li><a href="three-basic-gl.html">Basic example using three.js</a></li>
       <li>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -134,11 +134,11 @@ export class Spark {
 
   /**
    * Load an image and encode it to a compressed GPU texture.
-   * @param source - The image to encode. Can be a URL string, DOM image element, ImageBitmap, or GPUTexture
+   * @param source - The image to encode. Can be a URL string, DOM image element, ImageBitmap, HTMLCanvasElement, OffscreenCanvas, or GPUTexture
    * @param options - Optional configuration for encoding
    * @returns Promise resolving to the encoded GPU texture
    */
-  encodeTexture(source: string | HTMLImageElement | ImageBitmap | GPUTexture, options?: SparkEncodeOptions): Promise<GPUTexture>
+  encodeTexture(source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | GPUTexture, options?: SparkEncodeOptions): Promise<GPUTexture>
 
   /**
    * Returns list of compression formats supported on the current device.
@@ -166,7 +166,7 @@ export class Spark {
    * @param options - Encoding options
    * @returns Recommended encoding options with an explicit encoding format
    */
-  selectPreferredOptions(source: string | HTMLImageElement | ImageBitmap | GPUTexture, options?: SparkEncodeOptions): Promise<SparkEncodeOptions>
+  selectPreferredOptions(source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | GPUTexture, options?: SparkEncodeOptions): Promise<SparkEncodeOptions>
 
   /**
    * Get elapsed time for the last encoding operation (requires useTimestampQueries option).
@@ -272,11 +272,11 @@ export class SparkGL {
 
   /**
    * Load an image and encode it to a compressed WebGL texture.
-   * @param source - The image to encode. Can be a URL string, DOM image element, ImageBitmap, or WebGLTexture
+   * @param source - The image to encode. Can be a URL string, DOM image element, ImageBitmap, HTMLCanvasElement, OffscreenCanvas, or WebGLTexture
    * @param options - Optional configuration for encoding
    * @returns Promise resolving to an object containing the encoded texture and metadata
    */
-  encodeTexture(source: string | HTMLImageElement | ImageBitmap | WebGLTexture, options?: SparkEncodeOptions): Promise<SparkGLTextureResult>
+  encodeTexture(source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | WebGLTexture, options?: SparkEncodeOptions): Promise<SparkGLTextureResult>
 
   /**
    * Returns list of compression formats supported on the current device.

--- a/src/spark.js
+++ b/src/spark.js
@@ -473,8 +473,9 @@ class Spark {
   /**
    * Load an image and encode it to a compressed GPU texture.
    *
-   * @param {string | HTMLImageElement | ImageBitmap | GPUTexture} source
-   *        The image to encode. Can be a GPUTexture, URL, DOM image or ImageBitmap.
+   * @param {string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | GPUTexture} source
+   *        The image to encode. Can be a GPUTexture, URL, DOM image, ImageBitmap,
+   *        HTMLCanvasElement, or OffscreenCanvas.
    *
    * @param {Object} [options] - Optional configuration for encoding.
    *
@@ -517,8 +518,15 @@ class Spark {
   async encodeTexture(source, options = {}) {
     assert(this.#device, "Spark is not initialized")
 
-    // @@ TODO: Add support for canvas elements, blobs and ArrayBuffers.
-    const image = source instanceof Image || source instanceof ImageBitmap || source instanceof GPUTexture ? source : await loadImage(source)
+    // @@ TODO: Add support for blobs and ArrayBuffers.
+    const image =
+      source instanceof Image ||
+      source instanceof ImageBitmap ||
+      source instanceof HTMLCanvasElement ||
+      (typeof OffscreenCanvas !== "undefined" && source instanceof OffscreenCanvas) ||
+      source instanceof GPUTexture
+        ? source
+        : await loadImage(source)
     this.#log("Loaded image", image)
 
     const format = await this.#getBestMatchingFormat(options, image)


### PR DESCRIPTION
This was already working, but the documentation and typescript interface was incorrect. Updated both and added some examples to demonstrate the functionality.

<img width="641" height="640" alt="image" src="https://github.com/user-attachments/assets/9516c1fa-8cd2-4036-978c-daec0e9e7231" />
