### PR TITLE
Add dispose listener to delete/destroy gpu textures.

### DIFF
--- a/examples/three-basic-gl.html
+++ b/examples/three-basic-gl.html
@@ -15,6 +15,7 @@
     <script type="module">
       import * as THREE from "three"
       import { SparkGL } from "../src/spark-gl.js"
+      import { SparkThreeExternalTexture } from "@ludicon/spark.js/three"
 
       const errorHTML = `
       <div style="padding: 2em; font-family: sans-serif; max-width: 600px; margin: 5em auto; text-align: center;">
@@ -47,9 +48,12 @@
         generateMipmaps: true
       })
 
-      // Wrap the WebGL texture for three.js using ExternalTexture
-      const externalTex = new THREE.ExternalTexture(textureObject.texture)
-      //externalTex.image = { width: textureObject.width, height: textureObject.height }
+      // Wrap the WebGL texture for three.js. SparkThreeExternalTexture
+      // refcounts the shared resource and deletes the GL texture via the
+      // provided release callback once the final wrapper is disposed (the
+      // three.js WebGL backend does not manage ExternalTexture resources).
+      const release = tex => gl.deleteTexture(tex)
+      const externalTex = new SparkThreeExternalTexture(textureObject.texture, release)
 
       // Basic unlit material using the external texture
       const material = new THREE.MeshBasicMaterial({ map: externalTex })

--- a/examples/three-basic.html
+++ b/examples/three-basic.html
@@ -15,6 +15,7 @@
     <script type="module">
       import * as THREE from "three/webgpu"
       import { Spark } from "@ludicon/spark.js"
+      import { SparkThreeExternalTexture } from "@ludicon/spark.js/three"
 
       const errorHTML = `
       <div style="padding: 2em; font-family: sans-serif; max-width: 600px; margin: 5em auto; text-align: center;">
@@ -63,8 +64,11 @@
       // Load and encode texture using spark:
       const gpuTexture = await spark.encodeTexture("./assets/kodim23.avif", { srgb: true, flipY: true })
 
-      // Wrap the GPUTexture for three.js
-      const externalTex = new THREE.ExternalTexture(gpuTexture)
+      // Wrap the GPUTexture for three.js. SparkThreeExternalTexture refcounts
+      // the shared GPUTexture so clones and sibling wrappers stay valid until
+      // the last one is disposed.
+      const release = tex => tex.destroy()
+      const externalTex = new SparkThreeExternalTexture(gpuTexture, release)
 
       // Basic unlit material using the external texture
       const material = new THREE.MeshBasicMaterial({ map: externalTex })

--- a/package.json
+++ b/package.json
@@ -11,6 +11,10 @@
       "import": "./dist/spark.esm.js",
       "types": "./src/index.d.ts"
     },
+    "./three": {
+      "import": "./src/three.js",
+      "types": "./src/three.d.ts"
+    },
     "./three-gltf": {
       "import": "./src/three-gltf.js",
       "types": "./src/three-gltf.d.ts"
@@ -18,6 +22,8 @@
   },
   "files": [
     "dist",
+    "src/three.js",
+    "src/three.d.ts",
     "src/three-gltf.js",
     "src/three-gltf.d.ts",
     "src/index.d.ts",

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -266,6 +266,11 @@ export class SparkGL {
   static create(gl: WebGLRenderingContext | WebGL2RenderingContext, options?: SparkGLCreateOptions): SparkGL
 
   /**
+   * The underlying WebGL2 context.
+   */
+  readonly gl: WebGL2RenderingContext
+
+  /**
    * Destroys the SparkGL instance and all associated GPU resources.
    */
   dispose(): void

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -326,6 +326,11 @@ export class SparkGL {
       this.#preloadShaders(options.preload)
     }
   }
+
+  get gl() {
+    return this.#gl
+  }
+
   dispose() {
     const gl = this.#gl
 

--- a/src/three-gltf.js
+++ b/src/three-gltf.js
@@ -1,4 +1,5 @@
 import * as THREE from "three"
+import { SparkThreeExternalTexture } from "./three.js"
 
 const Channel = {
   R: 1, // 0001
@@ -183,15 +184,10 @@ class SparkLoader extends THREE.TextureLoader {
         // Handle both WebGPU (GPUTexture) and WebGL (object with .texture property)
         const isWebGL = textureObject.texture !== undefined
         const gpuTexture = isWebGL ? textureObject.texture : textureObject
-        const texture = new THREE.ExternalTexture(gpuTexture)
 
-        // ExternalTexture does not own the underlying resource, so release it when three disposes the wrapper.
-        if (isWebGL) {
-          const gl = this.spark.gl
-          texture.addEventListener("dispose", () => gl.deleteTexture(gpuTexture))
-        } else {
-          texture.addEventListener("dispose", () => gpuTexture.destroy())
-        }
+        const gl = this.spark.gl
+        const onRelease = isWebGL ? tex => gl.deleteTexture(tex) : tex => tex.destroy()
+        const texture = new SparkThreeExternalTexture(gpuTexture, onRelease)
 
         if (isWebGL) {
           texture.format = textureObject.format

--- a/src/three-gltf.js
+++ b/src/three-gltf.js
@@ -181,9 +181,19 @@ class SparkLoader extends THREE.TextureLoader {
       .encodeTexture(url, { format, srgb, mips, normal, preferLowQuality: this.options.preferLowQuality })
       .then(textureObject => {
         // Handle both WebGPU (GPUTexture) and WebGL (object with .texture property)
-        const gpuTexture = textureObject.texture !== undefined ? textureObject.texture : textureObject
+        const isWebGL = textureObject.texture !== undefined
+        const gpuTexture = isWebGL ? textureObject.texture : textureObject
         const texture = new THREE.ExternalTexture(gpuTexture)
-        if (textureObject.texture !== undefined) {
+
+        // ExternalTexture does not own the underlying resource, so release it when three disposes the wrapper.
+        if (isWebGL) {
+          const gl = this.spark.gl
+          texture.addEventListener("dispose", () => gl.deleteTexture(gpuTexture))
+        } else {
+          texture.addEventListener("dispose", () => gpuTexture.destroy())
+        }
+
+        if (isWebGL) {
           texture.format = textureObject.format
           texture.userData.byteLength = textureObject.byteLength
         }

--- a/src/three.d.ts
+++ b/src/three.d.ts
@@ -1,0 +1,22 @@
+// Type definitions for @ludicon/spark.js/three
+import { ExternalTexture } from "three"
+
+/**
+ * Callback invoked when the final SparkThreeExternalTexture wrapping a given
+ * resource is disposed. Required for WebGL (the three.js WebGL backend does
+ * not release ExternalTexture resources); unnecessary for WebGPU, where the
+ * three.js backend destroys the GPUTexture automatically.
+ */
+export type SparkThreeExternalTextureRelease = (resource: GPUTexture | WebGLTexture) => void
+
+/**
+ * ExternalTexture subclass that reference-counts the underlying GPU/GL
+ * texture so that multiple wrappers (including clones) can safely share a
+ * single resource. The resource is released only when the last wrapper is
+ * disposed.
+ */
+export class SparkThreeExternalTexture extends ExternalTexture {
+  constructor(sourceTexture?: GPUTexture | WebGLTexture | null, onRelease?: SparkThreeExternalTextureRelease | null)
+  copy(source: SparkThreeExternalTexture | ExternalTexture): this
+  dispose(): void
+}

--- a/src/three.js
+++ b/src/three.js
@@ -1,0 +1,64 @@
+import * as THREE from "three"
+
+// Refcount table keyed by the underlying GPU/GL texture. Multiple
+// SparkThreeExternalTexture wrappers may point at the same resource, but is
+// only released when the last wrapper is disposed.
+const refs = new WeakMap()
+
+function retain(resource) {
+  if (resource) refs.set(resource, (refs.get(resource) || 0) + 1)
+}
+
+/**
+ * ExternalTexture subclass that tracks shared ownership of the underlying
+ * GPU/GL texture across clones, so that disposing one wrapper doesn't destroy
+ * the resource out from under its siblings. three.js's WebGPU backend takes
+ * ownership of the underlying `GPUTexture` once the texture has been rendered
+ * with, and will call `GPUTexture.destroy()` on every `dispose()` thereafter;
+ * this class suppresses the 'dispose' event until the final wrapper goes away.
+ *
+ * A consequence of that suppression: user-registered `"dispose"` listeners on
+ * intermediate wrappers do not fire — only the listeners on the wrapper that
+ * actually releases the resource. That matches the refcount-zero semantics.
+ *
+ * @param {?(GPUTexture|WebGLTexture)} sourceTexture - The externally owned texture.
+ * @param {?(resource: GPUTexture|WebGLTexture) => void} [onRelease] - Called
+ *   when the final wrapper is disposed. For WebGL, pass
+ *   `tex => gl.deleteTexture(tex)`. For WebGPU, pass `tex => tex.destroy()`.
+ *   It is safe for three.js's backend to also release the resource — both
+ *   `GPUTexture.destroy()` and `gl.deleteTexture()` are idempotent — so this
+ *   callback covers the case where the texture was never rendered and three.js
+ *   therefore never registered its own dispose handler.
+ */
+export class SparkThreeExternalTexture extends THREE.ExternalTexture {
+  constructor(sourceTexture = null, onRelease = null) {
+    super(sourceTexture)
+    this._onRelease = onRelease
+    retain(sourceTexture)
+  }
+
+  copy(source) {
+    super.copy(source)
+    // Retain a new reference for the new wrapper and inherit the release callback so
+    // the clone can free the resource if it ends up being the last survivor.
+    retain(this.sourceTexture)
+    if (source instanceof SparkThreeExternalTexture) {
+      this._onRelease = source._onRelease
+    }
+    return this
+  }
+
+  dispose() {
+    const resource = this.sourceTexture
+    const remaining = resource ? (refs.get(resource) || 1) - 1 : 0
+
+    if (remaining > 0) {
+      refs.set(resource, remaining)
+      return
+    }
+
+    if (resource) refs.delete(resource)
+    super.dispose()
+    if (resource) this._onRelease?.(resource)
+  }
+}


### PR DESCRIPTION
External textures do not automatically delete/destroy the internal GL texture object of GPUTexture. Register event listener to ensure resources are released.