### PR TITLE
VideoFrame support in Spark and SparkGL

### DIFF
--- a/API.md
+++ b/API.md
@@ -169,12 +169,10 @@ Loads an image and encodes it to a compressed GPU texture.
   - **`flipY`** (`boolean`)
     Whether to vertically flip the image before encoding. Default: `false`.
 
-
-
 **Returns:**
 
-- **Spark (WebGPU)**: `Promise<GPUTexture>` - Compressed GPU texture
-- **SparkGL (WebGL2)**: `Promise<Object>` with properties:
+- **Spark (WebGPU)**: `Promise<GPUTexture>` - A promise resolving to the encoded WebGPU texture.
+- **SparkGL (WebGL2)**: `Promise<Object>` - A promise resolving to an object with properties:
   - `texture` (`WebGLTexture`) - The compressed WebGL texture
   - `format` (`number`) - WebGL internal format constant
   - `sparkFormat` (`string`) - Spark format name

--- a/API.md
+++ b/API.md
@@ -118,13 +118,14 @@ Loads an image and encodes it to a compressed GPU texture.
 
 **Parameters:**
 
-- **`source`** (`string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | GPUTexture | WebGLTexture`)  
+- **`source`** (`string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture | WebGLTexture`)  
   The image to encode. Can be:
   - URL string (loads image automatically)
   - DOM `<img>` element
   - `ImageBitmap` object
   - `HTMLCanvasElement`
   - `OffscreenCanvas`
+  - `VideoFrame`
   - `GPUTexture` (WebGPU only)
   - `WebGLTexture` (WebGL only)
 

--- a/API.md
+++ b/API.md
@@ -169,16 +169,20 @@ Loads an image and encodes it to a compressed GPU texture.
   - **`flipY`** (`boolean`)
     Whether to vertically flip the image before encoding. Default: `false`.
 
+  - **`outputTexture`** (`GPUTexture` for Spark, result object for SparkGL)
+    A previously-returned texture to reuse as the output, avoiding reallocation when re-encoding into the same shape repeatedly. Reused only when its width, height, mipmap count, and format match the resolved output; otherwise a fresh texture is allocated and returned. Useful for real-time use cases such as encoding successive video frames. Default: `undefined`.
+
 **Returns:**
 
 - **Spark (WebGPU)**: `Promise<GPUTexture>` - A promise resolving to the encoded WebGPU texture.
 - **SparkGL (WebGL2)**: `Promise<Object>` - A promise resolving to an object with properties:
   - `texture` (`WebGLTexture`) - The compressed WebGL texture
   - `format` (`number`) - WebGL internal format constant
-  - `sparkFormat` (`string`) - Spark format name
+  - `sparkFormat` (`string`) - Human-readable Spark format name
+  - `srgb` (`boolean`) - Whether the texture is encoded in an sRGB format
   - `width` (`number`) - Texture width
   - `height` (`number`) - Texture height
-  - `mipLevels` (`number`) - Number of mipmap levels
+  - `mipmapCount` (`number`) - Number of mipmap levels
   - `byteLength` (`number`) - Size of the texture data in bytes
 
 

--- a/README.md
+++ b/README.md
@@ -142,6 +142,9 @@ Load an image and encode it to a compressed GPU texture.
   - **`flipY`** (`boolean`)
     Whether to vertically flip the image before encoding. Default: `false`.
 
+  - **`outputTexture`** (`GPUTexture` for Spark, result object for SparkGL)
+    A previously-returned texture to reuse as the output, avoiding reallocation when re-encoding into the same shape repeatedly. Reused only when its width, height, mipmap count, and format match the resolved output; otherwise a fresh texture is allocated and returned. Default: `undefined`.
+
 #### Returns
 
 - **Spark (WebGPU)**: `Promise<GPUTexture>` - A promise resolving to the encoded WebGPU texture.

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ Load an image and encode it to a compressed GPU texture.
 
 #### Parameters
 
-- **`source`** (`string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | GPUTexture`)  
-  The image to encode. Can be a URL, DOM image, ImageBitmap, HTMLCanvasElement, OffscreenCanvas, or GPUTexture.
+- **`source`** (`string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture | WebGLTexture`)  
+  The image to encode.
 
 - **`options`** *(optional object)*
   Configuration options for encoding:
@@ -144,8 +144,15 @@ Load an image and encode it to a compressed GPU texture.
 
 #### Returns
 
-- `Promise<GPUTexture>` 
-  A promise resolving to the encoded WebGPU texture.
+- **Spark (WebGPU)**: `Promise<GPUTexture>` - A promise resolving to the encoded WebGPU texture.
+- **SparkGL (WebGL2)**: `Promise<Object>` A promise resolving to an object with properties:
+  - `texture` (`WebGLTexture`) - The compressed WebGL texture
+  - `format` (`number`) - WebGL internal format constant
+  - `sparkFormat` (`string`) - Spark format name
+  - `width` (`number`) - Texture width
+  - `height` (`number`) - Texture height
+  - `mipLevels` (`number`) - Number of mipmap levels
+  - `byteLength` (`number`) - Size of the texture data in bytes
 
 
 ## Integration with three.js

--- a/README.md
+++ b/README.md
@@ -145,14 +145,7 @@ Load an image and encode it to a compressed GPU texture.
 #### Returns
 
 - **Spark (WebGPU)**: `Promise<GPUTexture>` - A promise resolving to the encoded WebGPU texture.
-- **SparkGL (WebGL2)**: `Promise<Object>` A promise resolving to an object with properties:
-  - `texture` (`WebGLTexture`) - The compressed WebGL texture
-  - `format` (`number`) - WebGL internal format constant
-  - `sparkFormat` (`string`) - Spark format name
-  - `width` (`number`) - Texture width
-  - `height` (`number`) - Texture height
-  - `mipLevels` (`number`) - Number of mipmap levels
-  - `byteLength` (`number`) - Size of the texture data in bytes
+- **SparkGL (WebGL2)**: `Promise<Object>` - A promise resolving to an object containing the compressed WebGL texture.
 
 
 ## Integration with three.js

--- a/examples/index.html
+++ b/examples/index.html
@@ -19,6 +19,7 @@
       <li><a href="mipmaps.html">Mipmapping example</a></li>
       <li><a href="svg.html">SVG example</a></li>
       <li><a href="canvas.html">Canvas source example</a></li>
+      <li><a href="video.html">VideoFrame source example</a></li>
       <li><a href="realtime.html">Realtime procedural texture</a></li>
       <li><a href="three-basic.html">Basic example using three.js</a></li>
       <li><a href="three-gltf.html">GLTF example using three.js</a></li>
@@ -27,6 +28,7 @@
     <ul id="examples">
       <li><a href="basic-gl.html">Basic example</a></li>
       <li><a href="canvas-gl.html">Canvas source example</a></li>
+      <li><a href="video-gl.html">VideoFrame source example</a></li>
       <li><a href="mipmaps-gl.html">Mipmapping example</a></li>
       <li><a href="three-basic-gl.html">Basic example using three.js</a></li>
       <li>

--- a/examples/video-gl.html
+++ b/examples/video-gl.html
@@ -1,0 +1,240 @@
+<!doctype html>
+<html>
+  <!-- prettier-ignore -->
+  <head>
+    <title>spark.js - VideoFrame example (WebGL)</title>
+    <style>
+      body { margin: 0; font-family: sans-serif; }
+      canvas { display: block; }
+      #error {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+        padding: 2em;
+        max-width: 600px;
+        text-align: center;
+        background: rgba(255, 255, 255, 0.95);
+        border-radius: 10px;
+        box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+      }
+    </style>
+  </head>
+
+  <body>
+    <canvas id="glCanvas"></canvas>
+    <script type="module">
+      import { SparkGL } from "@ludicon/spark.js"
+
+      function showError(message) {
+        const errorDiv = document.createElement("div")
+        errorDiv.id = "error"
+        errorDiv.innerHTML = `
+          <h1>Error</h1>
+          <p>${message}</p>
+        `
+        document.body.appendChild(errorDiv)
+      }
+
+      // Load a video element and wait until a frame is available.
+      function loadVideo(url) {
+        const video = document.createElement("video")
+        video.src = url
+        video.crossOrigin = "anonymous"
+        video.muted = true
+        video.loop = true
+        video.playsInline = true
+        return new Promise((resolve, reject) => {
+          video.addEventListener("loadeddata", () => resolve(video), { once: true })
+          video.addEventListener("error", () => reject(new Error("Failed to load video")), { once: true })
+          video.play().catch(reject)
+        })
+      }
+
+      async function init() {
+        const canvas = document.getElementById("glCanvas")
+        const gl = canvas.getContext("webgl2", {
+          antialias: false,
+          depth: false,
+          stencil: false
+        })
+
+        if (!gl) {
+          showError("WebGL2 is not supported. Please use a modern browser.")
+          return
+        }
+
+        canvas.width = window.innerWidth
+        canvas.height = window.innerHeight
+
+        // Create SparkGL instance
+        const spark = SparkGL.create(gl, { preload: ["rgb"], verbose: true, cacheTempResources: true })
+
+        // Check supported formats
+        const supportedFormats = spark.getSupportedFormats()
+        console.log("Supported formats:", supportedFormats)
+
+        if (supportedFormats.length === 0) {
+          showError("No compressed texture formats are supported on this device. " + "Please try a different browser or device.")
+          return
+        }
+
+        // Load video and obtain a VideoFrame to encode.
+        const videoUrl = "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+        let video
+        try {
+          video = await loadVideo(videoUrl)
+        } catch (error) {
+          showError(`Failed to load video: ${error.message}`)
+          console.error(error)
+          return
+        }
+
+        let compressedTexture
+
+        // Create a simple shader to display the compressed texture
+        const vertexShaderSource = `#version 300 es
+          in vec2 position;
+          in vec2 texCoord;
+          out vec2 vTexCoord;
+
+          uniform vec2 uCanvasSize;
+          uniform vec2 uTextureSize;
+
+          void main() {
+            vTexCoord.x = texCoord.x;
+            vTexCoord.y = 1.0 - texCoord.y;
+
+            // Scale to maintain aspect ratio
+            float aspect = (uTextureSize.y * uCanvasSize.x) / (uCanvasSize.y * uTextureSize.x);
+            vec2 scale = vec2(
+              min(1.0, 1.0 / aspect),
+              min(1.0, aspect)
+            );
+
+            gl_Position = vec4(position * scale, 0.0, 1.0);
+          }
+        `
+
+        const fragmentShaderSource = `#version 300 es
+          precision mediump float;
+          in vec2 vTexCoord;
+          out vec4 fragColor;
+
+          uniform sampler2D uTexture;
+
+          void main() {
+            fragColor = texture(uTexture, vTexCoord);
+          }
+        `
+
+        function compileShader(type, source) {
+          const shader = gl.createShader(type)
+          gl.shaderSource(shader, source)
+          gl.compileShader(shader)
+
+          if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+            console.error("Shader compile error:", gl.getShaderInfoLog(shader))
+            gl.deleteShader(shader)
+            return null
+          }
+
+          return shader
+        }
+
+        const vertexShader = compileShader(gl.VERTEX_SHADER, vertexShaderSource)
+        const fragmentShader = compileShader(gl.FRAGMENT_SHADER, fragmentShaderSource)
+
+        const program = gl.createProgram()
+        gl.attachShader(program, vertexShader)
+        gl.attachShader(program, fragmentShader)
+        gl.linkProgram(program)
+
+        if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+          console.error("Program link error:", gl.getProgramInfoLog(program))
+          return
+        }
+
+        // Create vertex buffer for a fullscreen quad
+        // prettier-ignore
+        const positions = new Float32Array([
+          -1, -1, 0, 0, // bottom-left
+          1, -1, 1, 0, // bottom-right
+          -1, 1, 0, 1, // top-left
+          1, 1, 1, 1 // top-right
+        ])
+
+        const vertexBuffer = gl.createBuffer()
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer)
+        gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW)
+
+        const positionLoc = gl.getAttribLocation(program, "position")
+        const texCoordLoc = gl.getAttribLocation(program, "texCoord")
+        const canvasSizeLoc = gl.getUniformLocation(program, "uCanvasSize")
+        const textureSizeLoc = gl.getUniformLocation(program, "uTextureSize")
+        const textureLoc = gl.getUniformLocation(program, "uTexture")
+
+        // Setup rendering
+        async function render() {
+          // Capture the current playback frame as a VideoFrame and re-encode it.
+          // cacheTempResources keeps the intermediate textures and buffers around between calls.
+          const frame = new VideoFrame(video)
+          let prev = compressedTexture
+          try {
+            compressedTexture = await spark.encodeTexture(frame, {
+              format: "rgb",
+              mips: false
+            })
+          } finally {
+            frame.close()
+          }
+          if (prev) gl.deleteTexture(prev.texture)
+
+          gl.viewport(0, 0, canvas.width, canvas.height)
+          gl.clearColor(0.1, 0.1, 0.1, 1.0)
+          gl.clear(gl.COLOR_BUFFER_BIT)
+
+          gl.useProgram(program)
+
+          // Bind compressed texture
+          gl.activeTexture(gl.TEXTURE0)
+          gl.bindTexture(gl.TEXTURE_2D, compressedTexture.texture)
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE)
+          gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE)
+          gl.uniform1i(textureLoc, 0)
+
+          // Set uniforms
+          gl.uniform2f(canvasSizeLoc, canvas.width, canvas.height)
+          gl.uniform2f(textureSizeLoc, compressedTexture.width, compressedTexture.height)
+
+          // Setup vertex attributes
+          gl.bindBuffer(gl.ARRAY_BUFFER, vertexBuffer)
+          gl.enableVertexAttribArray(positionLoc)
+          gl.vertexAttribPointer(positionLoc, 2, gl.FLOAT, false, 16, 0)
+          gl.enableVertexAttribArray(texCoordLoc)
+          gl.vertexAttribPointer(texCoordLoc, 2, gl.FLOAT, false, 16, 8)
+
+          // Draw
+          gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4)
+
+          requestAnimationFrame(render)
+        }
+
+        // Handle resize
+        window.addEventListener("resize", () => {
+          canvas.width = window.innerWidth
+          canvas.height = window.innerHeight
+        })
+
+        render()
+      }
+
+      init().catch(error => {
+        console.error("Initialization error:", error)
+        showError(`Initialization failed: ${error.message}`)
+      })
+    </script>
+  </body>
+</html>

--- a/examples/video-gl.html
+++ b/examples/video-gl.html
@@ -176,19 +176,18 @@
 
         // Setup rendering
         async function render() {
-          // Capture the current playback frame as a VideoFrame and re-encode it.
-          // cacheTempResources keeps the intermediate textures and buffers around between calls.
+          // Capture the current playback frame as a VideoFrame and re-encode it,
+          // reusing the previous output texture to avoid reallocation.
           const frame = new VideoFrame(video)
-          let prev = compressedTexture
           try {
             compressedTexture = await spark.encodeTexture(frame, {
               format: "rgb",
-              mips: false
+              mips: false,
+              outputTexture: compressedTexture
             })
           } finally {
             frame.close()
           }
-          if (prev) gl.deleteTexture(prev.texture)
 
           gl.viewport(0, 0, canvas.width, canvas.height)
           gl.clearColor(0.1, 0.1, 0.1, 1.0)

--- a/examples/video.html
+++ b/examples/video.html
@@ -1,0 +1,304 @@
+<!doctype html>
+<html>
+  <!-- prettier-ignore -->
+  <head>
+    <title>spark.js - VideoFrame example (WebGPU)</title>
+    <style>
+      body { margin: 0; }
+      canvas { display: block; }
+    </style>
+  </head>
+
+  <body>
+    <script type="module">
+      import { Spark } from "@ludicon/spark.js"
+
+      const errorMessage = `
+          <div style="padding: 2em; font-family: sans-serif; max-width: 600px; margin: 5em auto; text-align: center;">
+            <h1>WebGPU Not Supported</h1>
+            <p>This demo requires a browser with WebGPU support.</p>
+            <p>Please try using <strong>Chrome</strong> or <strong>Edge</strong> with WebGPU enabled, or a recent version of <strong>Safari</strong> on macOS.</p>
+            <p>More information: <a href="https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API" target="_blank">MDN: WebGPU API</a></p>
+          </div>
+        `
+
+      async function initWebGPU() {
+        if (!navigator.gpu) {
+          document.body.innerHTML = errorMessage
+          throw new Error("WebGPU not supported")
+        }
+
+        let adapter = null
+        try {
+          adapter = await navigator.gpu.requestAdapter()
+        } catch (err) {
+          console.error("Error while requesting WebGPU adapter:", err)
+        }
+        if (!adapter) {
+          document.body.innerHTML = errorMessage
+          throw new Error("No appropriate GPUAdapter found")
+        }
+
+        // Request WebGPU features that Spark needs.
+        const requiredFeatures = Spark.getRequiredFeatures(adapter)
+        const device = await adapter.requestDevice({ requiredFeatures })
+
+        const canvas = document.createElement("canvas")
+        document.body.appendChild(canvas)
+
+        const context = canvas.getContext("webgpu")
+        const canvasFormat = navigator.gpu.getPreferredCanvasFormat()
+
+        context.configure({
+          device,
+          format: canvasFormat,
+          alphaMode: "opaque"
+        })
+
+        return { device, context, canvasFormat }
+      }
+
+      // Vertex shader
+      const vertexShader = `
+        struct Uniforms {
+          canvasWidth: f32,
+          canvasHeight: f32,
+          textureWidth: f32,
+          textureHeight: f32,
+        }
+        @group(0) @binding(0) var<uniform> uniforms: Uniforms;
+
+        struct VertexOutput {
+          @builtin(position) position: vec4f,
+          @location(0) texCoord: vec2f,
+        }
+
+        @vertex
+        fn main(@location(0) position: vec2f,
+                @location(1) texCoord: vec2f) -> VertexOutput {
+          var output: VertexOutput;
+
+          // Scale the position to maintain 1:1 aspect ratio
+          let aspect = (uniforms.textureHeight * uniforms.canvasWidth) / (uniforms.canvasHeight * uniforms.textureWidth);
+
+          let scale = vec2f(
+            min(1.0, 1.0 / aspect),
+            max(-1.0, -aspect));
+          let scaledPos = position * scale;
+
+          output.position = vec4f(scaledPos, 0.0, 1.0);
+          output.texCoord = texCoord;
+          return output;
+        }
+        `
+
+      // Fragment shader
+      const fragmentShader = `
+        @group(0) @binding(1) var t_diffuse: texture_2d<f32>;
+        @group(0) @binding(2) var s_diffuse: sampler;
+
+        @fragment
+        fn main(@location(0) texCoord: vec2f) -> @location(0) vec4f {
+          var color = textureSampleLevel(t_diffuse, s_diffuse, texCoord, 0.0).xyz;
+
+          return vec4f(color, 1.0);
+        }
+        `
+
+      // Create vertex buffer
+      function createVertexBuffer(device) {
+        // prettier-ignore
+        const vertices = new Float32Array([
+          // position (x, y), texCoord (u, v)
+          -1.0, -1.0, 0.0, 0.0, // bottom left
+           1.0, -1.0, 1.0, 0.0, // bottom right
+          -1.0,  1.0, 0.0, 1.0, // top left
+           1.0,  1.0, 1.0, 1.0  // top right
+        ])
+
+        const vertexBuffer = device.createBuffer({
+          size: vertices.byteLength,
+          usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST
+        })
+        device.queue.writeBuffer(vertexBuffer, 0, vertices)
+        return vertexBuffer
+      }
+
+      // Load a video element and wait until a frame is available.
+      function loadVideo(url) {
+        const video = document.createElement("video")
+        video.src = url
+        video.crossOrigin = "anonymous"
+        video.muted = true
+        video.loop = true
+        video.playsInline = true
+        return new Promise((resolve, reject) => {
+          video.addEventListener("loadeddata", () => resolve(video), { once: true })
+          video.addEventListener("error", () => reject(new Error("Failed to load video")), { once: true })
+          video.play().catch(reject)
+        })
+      }
+
+      // Main initialization
+      async function init() {
+        const { device, context, canvasFormat } = await initWebGPU()
+
+        // Create Spark instance.
+        const spark = await Spark.create(device, { preload: ["rgb"], verbose: true, cacheTempResources: true })
+
+        // Create vertex buffer
+        const vertexBuffer = createVertexBuffer(device)
+
+        // Create uniform buffer for canvas dimensions
+        const uniformBuffer = device.createBuffer({
+          size: 16, // 4 floats (width, height)
+          usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST
+        })
+
+        const videoUrl = "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4"
+        const video = await loadVideo(videoUrl)
+
+        let texture
+
+        // Create sampler
+        const sampler = device.createSampler({
+          magFilter: "linear",
+          minFilter: "linear"
+        })
+
+        // Create bind group layout
+        const bindGroupLayout = device.createBindGroupLayout({
+          entries: [
+            {
+              binding: 0,
+              visibility: GPUShaderStage.VERTEX,
+              buffer: { type: "uniform" }
+            },
+            {
+              binding: 1,
+              visibility: GPUShaderStage.FRAGMENT,
+              texture: { sampleType: "float" }
+            },
+            {
+              binding: 2,
+              visibility: GPUShaderStage.FRAGMENT,
+              sampler: { type: "filtering" }
+            }
+          ]
+        })
+
+        // Create pipeline layout
+        const pipelineLayout = device.createPipelineLayout({
+          bindGroupLayouts: [bindGroupLayout]
+        })
+
+        // Create render pipeline
+        const pipeline = device.createRenderPipeline({
+          layout: pipelineLayout,
+          vertex: {
+            module: device.createShaderModule({ code: vertexShader }),
+            entryPoint: "main",
+            buffers: [
+              {
+                arrayStride: 16,
+                attributes: [
+                  {
+                    // position
+                    shaderLocation: 0,
+                    offset: 0,
+                    format: "float32x2"
+                  },
+                  {
+                    // texCoord
+                    shaderLocation: 1,
+                    offset: 8,
+                    format: "float32x2"
+                  }
+                ]
+              }
+            ]
+          },
+          fragment: {
+            module: device.createShaderModule({ code: fragmentShader }),
+            entryPoint: "main",
+            targets: [
+              {
+                format: canvasFormat
+              }
+            ]
+          },
+          primitive: {
+            topology: "triangle-strip",
+            stripIndexFormat: "uint32"
+          }
+        })
+
+        // Handle window resize
+        const canvas = document.querySelector("canvas")
+        function resizeCanvas() {
+          canvas.width = window.innerWidth
+          canvas.height = window.innerHeight
+        }
+        window.addEventListener("resize", resizeCanvas)
+        resizeCanvas()
+
+        // Render function
+        async function render() {
+          // Capture the current playback frame as a VideoFrame and re-encode it,
+          // reusing the previous output texture to avoid reallocation.
+          const frame = new VideoFrame(video)
+          try {
+            texture = await spark.encodeTexture(frame, {
+              format: "rgb",
+              mips: false,
+              outputTexture: texture
+            })
+          } finally {
+            frame.close()
+          }
+
+          // Update uniform buffer with current dimensions
+          const uniformData = new Float32Array([canvas.width, canvas.height, texture.width, texture.height])
+          device.queue.writeBuffer(uniformBuffer, 0, uniformData)
+
+          // Create bind group for rendering with the compressed texture
+          const bindGroup = device.createBindGroup({
+            layout: bindGroupLayout,
+            entries: [
+              { binding: 0, resource: { buffer: uniformBuffer } },
+              { binding: 1, resource: texture.createView() },
+              { binding: 2, resource: sampler }
+            ]
+          })
+
+          const commandEncoder = device.createCommandEncoder()
+          const renderPass = commandEncoder.beginRenderPass({
+            colorAttachments: [
+              {
+                view: context.getCurrentTexture().createView(),
+                clearValue: { r: 0.0, g: 0.0, b: 0.0, a: 0.0 },
+                loadOp: "clear",
+                storeOp: "store"
+              }
+            ]
+          })
+
+          renderPass.setPipeline(pipeline)
+          renderPass.setBindGroup(0, bindGroup)
+          renderPass.setVertexBuffer(0, vertexBuffer)
+          renderPass.draw(4, 1, 0, 0)
+          renderPass.end()
+
+          device.queue.submit([commandEncoder.finish()])
+          requestAnimationFrame(render)
+        }
+
+        render()
+      }
+
+      init().catch(error => {
+        console.error("Error initializing WebGPU:", error)
+      })
+    </script>
+  </body>
+</html>

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -104,6 +104,17 @@ export interface SparkEncodeOptions {
    * @default false
    */
   flipY?: boolean
+
+  /**
+   * A previously-returned texture to reuse as the output, avoiding reallocation when
+   * re-encoding into the same shape repeatedly. Reused only when the existing texture
+   * matches the resolved width, height, mipmap count, and format; otherwise a fresh
+   * texture is allocated and returned.
+   *
+   * - For Spark: pass the `GPUTexture` returned by a prior `encodeTexture()`.
+   * - For SparkGL: pass the result object returned by a prior `encodeTexture()`.
+   */
+  outputTexture?: GPUTexture | SparkGLTextureResult
 }
 
 /**
@@ -134,11 +145,14 @@ export class Spark {
 
   /**
    * Load an image and encode it to a compressed GPU texture.
-   * @param source - The image to encode. Can be a URL string, DOM image element, ImageBitmap, HTMLCanvasElement, OffscreenCanvas, or GPUTexture
+   * @param source - The image to encode. Can be a URL string, DOM image element, ImageBitmap, HTMLCanvasElement, OffscreenCanvas, VideoFrame, or GPUTexture
    * @param options - Optional configuration for encoding
    * @returns Promise resolving to the encoded GPU texture
    */
-  encodeTexture(source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | GPUTexture, options?: SparkEncodeOptions): Promise<GPUTexture>
+  encodeTexture(
+    source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture,
+    options?: SparkEncodeOptions
+  ): Promise<GPUTexture>
 
   /**
    * Returns list of compression formats supported on the current device.
@@ -166,7 +180,10 @@ export class Spark {
    * @param options - Encoding options
    * @returns Recommended encoding options with an explicit encoding format
    */
-  selectPreferredOptions(source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | GPUTexture, options?: SparkEncodeOptions): Promise<SparkEncodeOptions>
+  selectPreferredOptions(
+    source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture,
+    options?: SparkEncodeOptions
+  ): Promise<SparkEncodeOptions>
 
   /**
    * Get elapsed time for the last encoding operation (requires useTimestampQueries option).
@@ -223,14 +240,9 @@ export interface SparkGLTextureResult {
   format: number
 
   /**
-   * Spark format name
-   */
-  sparkFormat: number
-
-  /**
    * Human-readable Spark format name
    */
-  sparkFormatName: string
+  sparkFormat: string
 
   /**
    * Texture width in pixels
@@ -245,7 +257,12 @@ export interface SparkGLTextureResult {
   /**
    * Number of mipmap levels
    */
-  mipLevels: number
+  mipmapCount: number
+
+  /**
+   * Whether the texture is encoded in an sRGB format
+   */
+  srgb: boolean
 
   /**
    * Size of the texture data in bytes
@@ -276,7 +293,10 @@ export class SparkGL {
    * @param options - Optional configuration for encoding
    * @returns Promise resolving to an object containing the encoded texture and metadata
    */
-  encodeTexture(source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | WebGLTexture, options?: SparkEncodeOptions): Promise<SparkGLTextureResult>
+  encodeTexture(
+    source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | WebGLTexture,
+    options?: SparkEncodeOptions
+  ): Promise<SparkGLTextureResult>
 
   /**
    * Returns list of compression formats supported on the current device.

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -698,10 +698,9 @@ export class SparkGL {
       options.outputTexture.width === width &&
       options.outputTexture.height === height &&
       options.outputTexture.mipmapCount === mipmapCount &&
-      options.outputTexture.format === glFormat &&
-      options.outputTexture.texture
+      options.outputTexture.format === glFormat
 
-    const compressedTexture = reuseOutput || gl.createTexture()
+    const compressedTexture = reuseOutput ? options.outputTexture.texture : gl.createTexture()
     gl.bindTexture(gl.TEXTURE_2D, compressedTexture)
     if (!reuseOutput) {
       gl.texStorage2D(gl.TEXTURE_2D, mipmapCount, glFormat, width, height)

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -501,8 +501,8 @@ export class SparkGL {
     // Diagnose image type
     this.#log(`Image type: ${image.constructor.name}`)
 
-    const width = image.width || image.videoWidth
-    const height = image.height || image.videoHeight
+    const width = image.displayWidth ?? image.width ?? image.videoWidth
+    const height = image.displayHeight ?? image.height ?? image.videoHeight
     assert(width && height)
 
     // Choose format. Default to "rgb" if no format specified
@@ -690,10 +690,22 @@ export class SparkGL {
       this.#log(`Generated ${mipmapCount} mipmap levels`)
     }
 
-    // Create output compressed texture
-    const compressedTexture = gl.createTexture()
+    // Create or reuse output compressed texture. The caller can pass a previous
+    // encodeTexture() result object as options.outputTexture; it is reused only when
+    // dimensions, format, and mipmap count match.
+    const reuseOutput =
+      options.outputTexture &&
+      options.outputTexture.width === width &&
+      options.outputTexture.height === height &&
+      options.outputTexture.mipmapCount === mipmapCount &&
+      options.outputTexture.format === glFormat &&
+      options.outputTexture.texture
+
+    const compressedTexture = reuseOutput || gl.createTexture()
     gl.bindTexture(gl.TEXTURE_2D, compressedTexture)
-    gl.texStorage2D(gl.TEXTURE_2D, mipmapCount, glFormat, width, height)
+    if (!reuseOutput) {
+      gl.texStorage2D(gl.TEXTURE_2D, mipmapCount, glFormat, width, height)
+    }
 
     // Set texture filtering parameters
     if (generateMipmaps) {
@@ -863,8 +875,7 @@ export class SparkGL {
       width,
       height,
       format: glFormat,
-      sparkFormat: format,
-      sparkFormatName: SparkFormatName[format],
+      sparkFormat: SparkFormatName[format],
       srgb,
       mipmapCount,
       byteLength

--- a/src/spark.js
+++ b/src/spark.js
@@ -206,14 +206,17 @@ function detectWebGPUFormats(device) {
 }
 
 function imageToByteArray(image) {
+  const width = image.displayWidth ?? image.width
+  const height = image.displayHeight ?? image.height
+
   const canvas = document.createElement("canvas")
-  canvas.width = image.width
-  canvas.height = image.height
+  canvas.width = width
+  canvas.height = height
 
   const ctx = canvas.getContext("2d")
   ctx.drawImage(image, 0, 0)
 
-  const imageData = ctx.getImageData(0, 0, image.width, image.height)
+  const imageData = ctx.getImageData(0, 0, width, height)
   return new Uint8Array(imageData.data.buffer)
 }
 
@@ -449,7 +452,15 @@ class Spark {
   async selectPreferredOptions(source, options = {}) {
     // Only load the image if the format has not been specified by the user.
     if (options.format == undefined || options.format == "auto") {
-      const image = source instanceof Image || source instanceof ImageBitmap || source instanceof GPUTexture ? source : await loadImage(source)
+      const image =
+        source instanceof Image ||
+        source instanceof ImageBitmap ||
+        source instanceof HTMLCanvasElement ||
+        (typeof OffscreenCanvas !== "undefined" && source instanceof OffscreenCanvas) ||
+        (typeof VideoFrame !== "undefined" && source instanceof VideoFrame) ||
+        source instanceof GPUTexture
+          ? source
+          : await loadImage(source)
 
       options.format = "auto"
       const format = await this.#getBestMatchingFormat(options, image)
@@ -473,9 +484,9 @@ class Spark {
   /**
    * Load an image and encode it to a compressed GPU texture.
    *
-   * @param {string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | GPUTexture} source
+   * @param {string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture} source
    *        The image to encode. Can be a GPUTexture, URL, DOM image, ImageBitmap,
-   *        HTMLCanvasElement, or OffscreenCanvas.
+   *        HTMLCanvasElement, OffscreenCanvas, or VideoFrame.
    *
    * @param {Object} [options] - Optional configuration for encoding.
    *
@@ -518,16 +529,32 @@ class Spark {
   async encodeTexture(source, options = {}) {
     assert(this.#device, "Spark is not initialized")
 
+    // Firefox's WebGPU does not yet accept VideoFrame in copyExternalImageToTexture.
+    // Convert to ImageBitmap and recurse so cleanup stays localized.
+    if (getFirefoxVersion() && typeof VideoFrame !== "undefined" && source instanceof VideoFrame) {
+      const bitmap = await createImageBitmap(source)
+      try {
+        return await this.encodeTexture(bitmap, options)
+      } finally {
+        bitmap.close()
+      }
+    }
+
     // @@ TODO: Add support for blobs and ArrayBuffers.
     const image =
       source instanceof Image ||
       source instanceof ImageBitmap ||
       source instanceof HTMLCanvasElement ||
       (typeof OffscreenCanvas !== "undefined" && source instanceof OffscreenCanvas) ||
+      (typeof VideoFrame !== "undefined" && source instanceof VideoFrame) ||
       source instanceof GPUTexture
         ? source
         : await loadImage(source)
     this.#log("Loaded image", image)
+
+    // VideoFrame uses displayWidth/displayHeight instead of width/height.
+    const srcWidth = image.displayWidth ?? image.width
+    const srcHeight = image.displayHeight ?? image.height
 
     const format = await this.#getBestMatchingFormat(options, image)
 
@@ -536,8 +563,8 @@ class Spark {
 
     // Round up the size to meet WebGPU requirements.
     // It would be great if this contstraint was optional. The only API still requiring it is D3D12.
-    const width = Math.ceil(image.width / 4) * 4
-    const height = Math.ceil(image.height / 4) * 4
+    const width = Math.ceil(srcWidth / 4) * 4
+    const height = Math.ceil(srcHeight / 4) * 4
     const blockSize = SparkBlockSize[format]
     const mipmaps = options.generateMipmaps || options.mips
 
@@ -570,7 +597,7 @@ class Spark {
       inputUsage |= GPUTextureUsage.STORAGE_BINDING
     }
 
-    const needsProcessing = options.flipY || width != image.width || height != image.height
+    const needsProcessing = options.flipY || width != srcWidth || height != srcHeight
 
     if (!needsProcessing && !(image instanceof GPUTexture)) {
       inputUsage |= GPUTextureUsage.RENDER_ATTACHMENT // This is only necessary for the copyExternalImageToTexture codepath.
@@ -624,8 +651,8 @@ class Spark {
         const needsTmpRealloc =
           !this.#cacheTempResources ||
           !this.#cachedTmpTexture ||
-          this.#cachedTmpTexture.width < image.width ||
-          this.#cachedTmpTexture.height < image.height
+          this.#cachedTmpTexture.width < srcWidth ||
+          this.#cachedTmpTexture.height < srcHeight
 
         if (this.#cacheTempResources && this.#cachedTmpTexture && !needsTmpRealloc) {
           tmpTexture = this.#cachedTmpTexture
@@ -634,7 +661,7 @@ class Spark {
             this.#cachedTmpTexture.destroy()
           }
           tmpTexture = this.#device.createTexture({
-            size: [image.width, image.height, 1],
+            size: [srcWidth, srcHeight, 1],
             mipLevelCount: 1,
             format: "rgba8unorm",
             // RENDER_ATTACHMENT usage is necessary for copyExternalImageToTexture
@@ -646,7 +673,7 @@ class Spark {
           }
         }
 
-        this.#device.queue.copyExternalImageToTexture({ source: image }, { texture: tmpTexture }, { width: image.width, height: image.height })
+        this.#device.queue.copyExternalImageToTexture({ source: image }, { texture: tmpTexture }, { width: srcWidth, height: srcHeight })
 
         this.#processInputTexture(commandEncoder, tmpTexture, inputTexture, width, height, colorMode, options.flipY)
       }

--- a/vite.config.examples.js
+++ b/vite.config.examples.js
@@ -52,6 +52,8 @@ export default defineConfig({
         mipmaps: resolve(__dirname, "examples/mipmaps.html"),
         "mipmaps-gl": resolve(__dirname, "examples/mipmaps-gl.html"),
         svg: resolve(__dirname, "examples/svg.html"),
+        video: resolve(__dirname, "examples/video.html"),
+        "video-gl": resolve(__dirname, "examples/video-gl.html"),
         realtime: resolve(__dirname, "examples/realtime.html"),
         "three-basic": resolve(__dirname, "examples/three-basic.html"),
         "three-basic-gl": resolve(__dirname, "examples/three-basic-gl.html"),


### PR DESCRIPTION
This PR adds support for video frames as the source argument in `encodeTexture`. Adds two examples to demonstrate video playback and real-time compression in WebGL and WebGPU.

`gl.texImage2D` and `copyExternalImageToTexture` already support `VideoFrame` as input sources, so the main change that was necessary is to support reading the image extents from `displayWidth`/`displayHeight` instead of `width`/`height`.

There's one caveat, though. Firefox does not support `VideoFrame` in `copyExternalImageToTexture` yet. To work around that we first call `createImageBitmap(frame)` to obtain an `ImageBitmap` that we can pass to `copyExternalImageToTexture`. This is a known problem, already reported in: https://bugzilla.mozilla.org/show_bug.cgi?id=1975308

Additionally, this PR adds support for the `outputTexture` option argument in SparkGL to allow reusing an existing texture and avoid resource reallocation on every frame.