### PR TITLE
Add support for ImageDecoder API

### DIFF
--- a/API.md
+++ b/API.md
@@ -118,9 +118,10 @@ Loads an image and encodes it to a compressed GPU texture.
 
 **Parameters:**
 
-- **`source`** (`string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture | WebGLTexture`)  
+- **`source`** (`string | Blob | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture | WebGLTexture`)  
   The image to encode. Can be:
   - URL string (loads image automatically)
+  - `Blob` (encoded image bytes; decoded internally via `ImageDecoder` when supported, else `createImageBitmap`)
   - DOM `<img>` element
   - `ImageBitmap` object
   - `HTMLCanvasElement`

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Load an image and encode it to a compressed GPU texture.
 
 #### Parameters
 
-- **`source`** (`string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture | WebGLTexture`)  
+- **`source`** (`string | Blob | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture | WebGLTexture`)  
   The image to encode.
 
 - **`options`** *(optional object)*

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -150,7 +150,7 @@ export class Spark {
    * @returns Promise resolving to the encoded GPU texture
    */
   encodeTexture(
-    source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture,
+    source: string | Blob | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture,
     options?: SparkEncodeOptions
   ): Promise<GPUTexture>
 
@@ -181,7 +181,7 @@ export class Spark {
    * @returns Recommended encoding options with an explicit encoding format
    */
   selectPreferredOptions(
-    source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture,
+    source: string | Blob | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | GPUTexture,
     options?: SparkEncodeOptions
   ): Promise<SparkEncodeOptions>
 
@@ -294,7 +294,7 @@ export class SparkGL {
    * @returns Promise resolving to an object containing the encoded texture and metadata
    */
   encodeTexture(
-    source: string | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | WebGLTexture,
+    source: string | Blob | HTMLImageElement | ImageBitmap | HTMLCanvasElement | OffscreenCanvas | VideoFrame | WebGLTexture,
     options?: SparkEncodeOptions
   ): Promise<SparkGLTextureResult>
 

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -1,6 +1,6 @@
 // WebGL implementation of spark.js texture compression API
 import glslShaders from "./shaders/glsl-shaders.js"
-import { assert, loadImage } from "./utils.js"
+import { assert, loadImage, loadImageFromBlob } from "./utils.js"
 
 const SparkFormat = {
   ASTC_4x4_RGB: 0,
@@ -493,10 +493,10 @@ export class SparkGL {
   async encodeTexture(image, options = {}) {
     const gl = this.#gl
 
-    // Resolve URLs by recursing on the loaded image so we can close it (loadImage may
-    // return a VideoFrame on Firefox).
-    if (typeof image === "string") {
-      const loaded = await loadImage(image)
+    // Decode raw byte sources (URLs, Blobs) and recurse so we can close the resulting image
+    // (loadImage / loadImageFromBlob may return a VideoFrame on Firefox).
+    if (typeof image === "string" || image instanceof Blob) {
+      const loaded = image instanceof Blob ? await loadImageFromBlob(image) : await loadImage(image)
       try {
         return await this.encodeTexture(loaded, options)
       } finally {

--- a/src/spark.js
+++ b/src/spark.js
@@ -623,7 +623,6 @@ class Spark {
       : srgb
         ? ["rgba8unorm", "rgba8unorm-srgb"]
         : ["rgba8unorm"]
-    // this.#useFragmentShader
 
     const needsProcessing = options.flipY || width != srcWidth || height != srcHeight
 

--- a/src/spark.js
+++ b/src/spark.js
@@ -1,5 +1,5 @@
 import shaders from "./shaders/wgsl-shaders.js"
-import { assert, loadImage, getSafariVersion, getFirefoxVersion } from "./utils.js"
+import { assert, loadImage, loadImageFromBlob, getSafariVersion, getFirefoxVersion } from "./utils.js"
 
 const SparkFormat = {
   ASTC_4x4_RGB: 0,
@@ -459,7 +459,7 @@ class Spark {
         (typeof OffscreenCanvas !== "undefined" && source instanceof OffscreenCanvas) ||
         (typeof VideoFrame !== "undefined" && source instanceof VideoFrame) ||
         source instanceof GPUTexture
-      const image = direct ? source : await loadImage(source)
+      const image = direct ? source : source instanceof Blob ? await loadImageFromBlob(source) : await loadImage(source)
 
       try {
         options.format = "auto"
@@ -546,7 +546,7 @@ class Spark {
       source instanceof GPUTexture
 
     if (!isDirectSource) {
-      const loaded = await loadImage(source)
+      const loaded = source instanceof Blob ? await loadImageFromBlob(source) : await loadImage(source)
       try {
         return await this.encodeTexture(loaded, options)
       } finally {
@@ -557,6 +557,10 @@ class Spark {
     // Firefox's WebGPU does not yet accept VideoFrame in copyExternalImageToTexture.
     // Convert to ImageBitmap and recurse so cleanup stays localized.
     if (getFirefoxVersion() && isVideoFrame) {
+      if (source.format == "BGRA" || source.format == "BGRX") {
+        // Choose BGRA format to avoid pixel format conversion in copyExternalImageToTexture.
+        options.input_bgra = true
+      }
       const bitmap = await createImageBitmap(source)
       try {
         return await this.encodeTexture(bitmap, options)
@@ -595,7 +599,6 @@ class Spark {
     if (options.normal) colorMode = ColorMode.Normal
 
     const webgpuFormat = SparkWebGPUFormats[format] + (srgb ? "-srgb" : "")
-    const viewFormats = srgb ? ["rgba8unorm", "rgba8unorm-srgb"] : ["rgba8unorm"]
 
     // For now let's just create a texture. Ideally we would use a staging buffer, but in WebGPU it's not possible to create a bufer that
     // both the host can write to and the device can read from a compute shader, so in practice we would need two buffers and to perform
@@ -612,6 +615,15 @@ class Spark {
     } else {
       inputUsage |= GPUTextureUsage.STORAGE_BINDING
     }
+    const inputFormat = options.input_bgra ? "bgra8unorm" : "rgba8unorm"
+    const inputViewFormats = options.input_bgra
+      ? srgb
+        ? ["bgra8unorm", "bgra8unorm-srgb"]
+        : ["bgra8unorm"]
+      : srgb
+        ? ["rgba8unorm", "rgba8unorm-srgb"]
+        : ["rgba8unorm"]
+    // this.#useFragmentShader
 
     const needsProcessing = options.flipY || width != srcWidth || height != srcHeight
 
@@ -636,6 +648,7 @@ class Spark {
         !this.#cachedInputTexture ||
         this.#cachedInputTexture.width < width ||
         this.#cachedInputTexture.height < height ||
+        this.#cachedInputTexture.format != inputFormat ||
         this.#cachedInputTexture.mipLevelCount < mipmapCount
 
       if (this.#cacheTempResources && this.#cachedInputTexture && !needsRealloc) {
@@ -647,9 +660,9 @@ class Spark {
         inputTexture = this.#device.createTexture({
           size: [width, height, 1],
           mipLevelCount: mipmapCount,
-          format: "rgba8unorm",
+          format: inputFormat,
           usage: inputUsage,
-          viewFormats: viewFormats
+          viewFormats: inputViewFormats
         })
         if (this.#cacheTempResources) {
           this.#cachedInputTexture = inputTexture
@@ -665,7 +678,11 @@ class Spark {
       } else {
         // Create or reuse temporary texture using the input size
         const needsTmpRealloc =
-          !this.#cacheTempResources || !this.#cachedTmpTexture || this.#cachedTmpTexture.width < srcWidth || this.#cachedTmpTexture.height < srcHeight
+          !this.#cacheTempResources ||
+          !this.#cachedTmpTexture ||
+          this.#cachedTmpTexture.width < srcWidth ||
+          this.#cachedTmpTexture.height < srcHeight ||
+          this.#cachedInputTexture.format != inputFormat
 
         if (this.#cacheTempResources && this.#cachedTmpTexture && !needsTmpRealloc) {
           tmpTexture = this.#cachedTmpTexture
@@ -676,10 +693,10 @@ class Spark {
           tmpTexture = this.#device.createTexture({
             size: [srcWidth, srcHeight, 1],
             mipLevelCount: 1,
-            format: "rgba8unorm",
+            format: inputFormat,
             // RENDER_ATTACHMENT usage is necessary for copyExternalImageToTexture
             usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST | GPUTextureUsage.RENDER_ATTACHMENT,
-            viewFormats: viewFormats
+            viewFormats: inputViewFormats
           })
           if (this.#cacheTempResources) {
             this.#cachedTmpTexture = tmpTexture

--- a/src/utils.js
+++ b/src/utils.js
@@ -35,6 +35,53 @@ export function isSvgUrl(url) {
   return /\.svg(?:$|\?)/i.test(url) || /^data:image\/svg\+xml[,;]/i.test(url)
 }
 
+const MIME_FROM_EXT = {
+  avif: "image/avif",
+  webp: "image/webp",
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif"
+}
+
+function mimeTypeFromUrl(url) {
+  const ext = url.split("?")[0].split("#")[0].split(".").pop()?.toLowerCase()
+  return MIME_FROM_EXT[ext]
+}
+
+export async function loadImageDecoder(url) {
+  const res = await fetch(url, { mode: "cors" })
+  if (!res.ok) throw new Error(`HTTP ${res.status} for ${url}`)
+
+  const contentType = res.headers.get("Content-Type")?.split(";")[0].trim()
+  const mimeType = contentType || mimeTypeFromUrl(url)
+
+  if (!mimeType || !(await ImageDecoder.isTypeSupported(mimeType))) {
+    // Fall back to createImageBitmap when ImageDecoder can't handle the type.
+    const blob = await res.blob()
+    return createImageBitmap(blob, {
+      imageOrientation: "none",
+      colorSpaceConversion: "none",
+      premultiplyAlpha: "none"
+    })
+  }
+
+  const decoder = new ImageDecoder({
+    data: res.body,
+    type: mimeType,
+    colorSpaceConversion: "none",
+    preferAnimation: false
+  })
+
+  try {
+    // Returns a VideoFrame; caller is responsible for calling .close() on it.
+    const { image } = await decoder.decode({ frameIndex: 0, completeFramesOnly: true })
+    return image
+  } finally {
+    decoder.close()
+  }
+}
+
 export function loadImageElement(url) {
   return new Promise((resolve, reject) => {
     const img = new Image()
@@ -60,10 +107,18 @@ export async function loadImageBitmap(url) {
 }
 
 const webkitVersion = getSafariVersion()
+const firefoxVersion = getFirefoxVersion()
 
 // Safari 18.2 (Tahoe) introduced support for SVG in copyExternalImageToTexture
 const SAFARI_TAHOE_VERSION = 619.1 // Safari 18.2
 const needsSvgImageBitmapWorkaround = webkitVersion && webkitVersion < SAFARI_TAHOE_VERSION
+
+// Safari always prefers image element over image bitmap.
+// @@ Does this handle RGBA images correctly?
+const useImageElement = webkitVersion
+
+// ImageDecoder is only available in Firefox 133+ and Chrome, but Chrome does not support AVIF.
+const useImageDecoder = (firefoxVersion && firefoxVersion >= 133) || true
 
 async function convertImageElementToImageBitmap(img) {
   // Render HTMLImageElement to canvas, then create ImageBitmap
@@ -90,9 +145,36 @@ export async function loadImage(url) {
     // Older Safari: load SVG as HTMLImageElement, then convert to ImageBitmap
     const img = await loadImageElement(url)
     return convertImageElementToImageBitmap(img)
-  } else if (isSvg || webkitVersion) {
+  } else if (isSvg || useImageElement) {
     return loadImageElement(url)
+  } else if (useImageDecoder) {
+    return loadImageDecoder(url)
   } else {
     return loadImageBitmap(url)
   }
+}
+
+// Decode a Blob to either a VideoFrame (via ImageDecoder) or an ImageBitmap. Mirrors the
+// dispatch in loadImageDecoder/loadImageBitmap but skips the fetch since the bytes are in hand.
+// Caller owns the returned object (close() it when done).
+export async function loadImageFromBlob(blob) {
+  if (useImageDecoder && blob.type && (await ImageDecoder.isTypeSupported(blob.type))) {
+    const decoder = new ImageDecoder({
+      data: blob.stream(),
+      type: blob.type,
+      colorSpaceConversion: "none",
+      preferAnimation: false
+    })
+    try {
+      const { image } = await decoder.decode({ frameIndex: 0, completeFramesOnly: true })
+      return image
+    } finally {
+      decoder.close()
+    }
+  }
+  return createImageBitmap(blob, {
+    imageOrientation: "none",
+    colorSpaceConversion: "none",
+    premultiplyAlpha: "none"
+  })
 }


### PR DESCRIPTION
This adds support for the ImageDecoder API and enables it in Firefox, which improves performance as described in this blog post:

https://www.ludicon.com/castano/blog/2026/05/image-loading-on-the-web/

Note, pixel format defaults to BGRA on Firefox, which reduces the need for pixel format conversions in the main thread.

Additionally it also adds support for loading images from Blobs in addition to all the other existing image sources.