### PR TITLE
Add support for texture-compression-unaligned.

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -22,6 +22,7 @@
       <li><a href="canvas.html">Canvas source example</a></li>
       <li><a href="video.html">VideoFrame source example</a></li>
       <li><a href="realtime.html">Realtime procedural texture</a></li>
+      <li><a href="unaligned.html">Unaligned texture size example</a></li>
       <li><a href="three-basic.html">Basic example using three.js</a></li>
       <li><a href="three-gltf.html">GLTF example using three.js</a></li>
     </ul>

--- a/examples/unaligned.html
+++ b/examples/unaligned.html
@@ -1,0 +1,209 @@
+<!doctype html>
+<html>
+  <!-- prettier-ignore -->
+  <head>
+    <title>spark.js - Unaligned texture example (WebGPU)</title>
+    <style>
+      body { margin: 0; background: #222; }
+      canvas { display: block; }
+      #info {
+        position: fixed; top: 0; left: 0; right: 0;
+        padding: 0.75em 1em;
+        font-family: system-ui, sans-serif; font-size: 14px; line-height: 1.4;
+        color: #fff; background: rgba(0,0,0,0.55); pointer-events: none;
+      }
+      #info .supported { color: #6f6; font-weight: bold; }
+      #info .unsupported { color: #f66; font-weight: bold; }
+    </style>
+  </head>
+
+  <body>
+    <div id="info">…</div>
+    <script type="module">
+      import { Spark } from "@ludicon/spark.js"
+
+      const errorMessage = `
+          <div style="padding: 2em; font-family: sans-serif; max-width: 600px; margin: 5em auto; text-align: center;">
+            <h1>WebGPU Not Supported</h1>
+            <p>This demo requires a browser with WebGPU support.</p>
+          </div>
+        `
+
+      async function initWebGPU() {
+        if (!navigator.gpu) {
+          document.body.innerHTML = errorMessage
+          throw new Error("WebGPU not supported")
+        }
+        const adapter = await navigator.gpu.requestAdapter()
+        if (!adapter) {
+          document.body.innerHTML = errorMessage
+          throw new Error("No appropriate GPUAdapter found")
+        }
+        // getRequiredFeatures requests "texture-compression-unaligned" when the adapter exposes it.
+        const requiredFeatures = Spark.getRequiredFeatures(adapter)
+        const device = await adapter.requestDevice({ requiredFeatures })
+
+        const canvas = document.createElement("canvas")
+        document.body.appendChild(canvas)
+        const context = canvas.getContext("webgpu")
+        const canvasFormat = navigator.gpu.getPreferredCanvasFormat()
+        context.configure({ device, format: canvasFormat, alphaMode: "opaque" })
+
+        return { device, context, canvasFormat }
+      }
+
+      // Draw an odd-sized texture with 1-texel wide vertical black & white bars.
+      // The 255 size is intentionally not a multiple of 4: without the
+      // texture-compression-unaligned feature, Spark must round the size up to 256,
+      // which resamples this Nyquist-frequency pattern and destroys the bars.
+      function createSourceCanvas(size = 255) {
+        const canvas = document.createElement("canvas")
+        canvas.width = size
+        canvas.height = size
+        const ctx = canvas.getContext("2d")
+        const image = ctx.createImageData(size, size)
+        const data = image.data
+        for (let y = 0; y < size; y++) {
+          for (let x = 0; x < size; x++) {
+            const v = x % 2 === 0 ? 0 : 255
+            const i = (y * size + x) * 4
+            data[i + 0] = v
+            data[i + 1] = v
+            data[i + 2] = v
+            data[i + 3] = 255
+          }
+        }
+        ctx.putImageData(image, 0, 0)
+        return canvas
+      }
+
+      const vertexShader = `
+        struct Uniforms { canvasWidth: f32, canvasHeight: f32, textureWidth: f32, textureHeight: f32 }
+        @group(0) @binding(0) var<uniform> uniforms: Uniforms;
+        struct VertexOutput { @builtin(position) position: vec4f, @location(0) texCoord: vec2f }
+        @vertex
+        fn main(@location(0) position: vec2f, @location(1) texCoord: vec2f) -> VertexOutput {
+          var output: VertexOutput;
+          let aspect = (uniforms.textureHeight * uniforms.canvasWidth) / (uniforms.canvasHeight * uniforms.textureWidth);
+          let scale = vec2f(min(1.0, 1.0 / aspect), max(-1.0, -aspect));
+          output.position = vec4f(position * scale, 0.0, 1.0);
+          output.texCoord = texCoord;
+          return output;
+        }`
+
+      const fragmentShader = `
+        @group(0) @binding(1) var t_diffuse: texture_2d<f32>;
+        @group(0) @binding(2) var s_diffuse: sampler;
+        @fragment
+        fn main(@location(0) texCoord: vec2f) -> @location(0) vec4f {
+          return vec4f(textureSampleLevel(t_diffuse, s_diffuse, texCoord, 0.0).xyz, 1.0);
+        }`
+
+      async function init() {
+        const { device, context, canvasFormat } = await initWebGPU()
+        const spark = await Spark.create(device, { preload: ["rgb"], verbose: true })
+
+        const supportsUnaligned = device.features.has("texture-compression-unaligned")
+        const info = document.getElementById("info")
+        info.innerHTML = supportsUnaligned
+          ? `<span class="supported">texture-compression-unaligned: supported</span>`
+          : `<span class="unsupported">texture-compression-unaligned: not supported</span>`
+
+        // Use an HTMLCanvasElement as the encodeTexture source.
+        const source = createSourceCanvas(253)
+        const texture = await spark.encodeTexture(source)
+
+        // prettier-ignore
+        const vertices = new Float32Array([
+          -1.0, -1.0, 0.0, 0.0,
+           1.0, -1.0, 1.0, 0.0,
+          -1.0,  1.0, 0.0, 1.0,
+           1.0,  1.0, 1.0, 1.0
+        ])
+        const vertexBuffer = device.createBuffer({ size: vertices.byteLength, usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST })
+        device.queue.writeBuffer(vertexBuffer, 0, vertices)
+
+        const uniformBuffer = device.createBuffer({ size: 16, usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST })
+        // Nearest filtering so each texel is visible and the resampling artifacts are obvious.
+        const sampler = device.createSampler({ magFilter: "nearest", minFilter: "nearest" })
+
+        const bindGroupLayout = device.createBindGroupLayout({
+          entries: [
+            { binding: 0, visibility: GPUShaderStage.VERTEX, buffer: { type: "uniform" } },
+            { binding: 1, visibility: GPUShaderStage.FRAGMENT, texture: { sampleType: "float" } },
+            { binding: 2, visibility: GPUShaderStage.FRAGMENT, sampler: { type: "non-filtering" } }
+          ]
+        })
+        const pipelineLayout = device.createPipelineLayout({ bindGroupLayouts: [bindGroupLayout] })
+        const bindGroup = device.createBindGroup({
+          layout: bindGroupLayout,
+          entries: [
+            { binding: 0, resource: { buffer: uniformBuffer } },
+            { binding: 1, resource: texture.createView() },
+            { binding: 2, resource: sampler }
+          ]
+        })
+
+        const pipeline = device.createRenderPipeline({
+          layout: pipelineLayout,
+          vertex: {
+            module: device.createShaderModule({ code: vertexShader }),
+            entryPoint: "main",
+            buffers: [
+              {
+                arrayStride: 16,
+                attributes: [
+                  { shaderLocation: 0, offset: 0, format: "float32x2" },
+                  { shaderLocation: 1, offset: 8, format: "float32x2" }
+                ]
+              }
+            ]
+          },
+          fragment: {
+            module: device.createShaderModule({ code: fragmentShader }),
+            entryPoint: "main",
+            targets: [{ format: canvasFormat }]
+          },
+          primitive: { topology: "triangle-strip", stripIndexFormat: "uint32" }
+        })
+
+        function resizeCanvas() {
+          const displayWidth = window.innerWidth
+          const displayHeight = window.innerHeight
+          const canvas = document.querySelector("canvas")
+          if (canvas.width !== displayWidth || canvas.height !== displayHeight) {
+            canvas.width = displayWidth
+            canvas.height = displayHeight
+            device.queue.writeBuffer(uniformBuffer, 0, new Float32Array([displayWidth, displayHeight, texture.width, texture.height]))
+          }
+        }
+        window.addEventListener("resize", resizeCanvas)
+        resizeCanvas()
+
+        function render() {
+          const commandEncoder = device.createCommandEncoder()
+          const renderPass = commandEncoder.beginRenderPass({
+            colorAttachments: [
+              {
+                view: context.getCurrentTexture().createView(),
+                clearValue: { r: 0, g: 0, b: 0, a: 1 },
+                loadOp: "clear",
+                storeOp: "store"
+              }
+            ]
+          })
+          renderPass.setPipeline(pipeline)
+          renderPass.setBindGroup(0, bindGroup)
+          renderPass.setVertexBuffer(0, vertexBuffer)
+          renderPass.draw(4, 1, 0, 0)
+          renderPass.end()
+          device.queue.submit([commandEncoder.finish()])
+          requestAnimationFrame(render)
+        }
+        render()
+      }
+
+      init().catch(err => console.error("Error:", err))
+    </script>
+  </body>
+</html>

--- a/src/spark.js
+++ b/src/spark.js
@@ -259,6 +259,7 @@ class Spark {
   #supportsFloat16
   #useFragmentShader = false
   #compatibilityMode = false
+  #supportsUnalignedTextures = false
   #pipelines = []
   #mipmapPipeline
   #magicMipmapPipeline
@@ -442,6 +443,11 @@ class Spark {
       features.push("timestamp-query")
     }
 
+    // Request texture-compression-unaligned support.
+    if (adapter.features.has("texture-compression-unaligned")) {
+      features.push("texture-compression-unaligned")
+    }
+
     return features
   }
 
@@ -585,10 +591,9 @@ class Spark {
     // Start loading the pipeline as soon as we know the format.
     const pipelinePromise = this.#loadPipeline(format)
 
-    // Round up the size to meet WebGPU requirements.
-    // It would be great if this contstraint was optional. The only API still requiring it is D3D12.
-    const width = Math.ceil(srcWidth / 4) * 4
-    const height = Math.ceil(srcHeight / 4) * 4
+    // Round up the size to meet WebGPU's 4-texel alignment requirement, unless the texture-compression-unaligned feature lifts it.
+    const width = this.#supportsUnalignedTextures ? srcWidth : Math.ceil(srcWidth / 4) * 4
+    const height = this.#supportsUnalignedTextures ? srcHeight : Math.ceil(srcHeight / 4) * 4
     const blockSize = SparkBlockSize[format]
     const mipmaps = options.generateMipmaps || options.mips
 
@@ -939,6 +944,8 @@ class Spark {
     this.#cacheTempResources = cacheTempResources
     // Core devices expose the "core-features-and-limits" feature; compat devices don't.
     this.#compatibilityMode = !device.features.has("core-features-and-limits")
+    // When supported, texture-compression-unaligned lifts the block alignment requirement.
+    this.#supportsUnalignedTextures = device.features.has("texture-compression-unaligned")
 
     this.#supportedFormats = detectWebGPUFormats(this.#device)
     this.#defaultSampler = this.#device.createSampler({

--- a/vite.config.examples.js
+++ b/vite.config.examples.js
@@ -57,6 +57,7 @@ export default defineConfig({
         video: resolve(__dirname, "examples/video.html"),
         "video-gl": resolve(__dirname, "examples/video-gl.html"),
         realtime: resolve(__dirname, "examples/realtime.html"),
+        unaligned: resolve(__dirname, "examples/unaligned.html"),
         "three-basic": resolve(__dirname, "examples/three-basic.html"),
         "three-basic-gl": resolve(__dirname, "examples/three-basic-gl.html"),
         "three-gltf": resolve(__dirname, "examples/three-gltf.html"),


### PR DESCRIPTION
This adds support for the `texture-compression-unaligned` feature discussed in: https://github.com/gpuweb/gpuweb/issues/2006

Without support for unaligned block-compressed textures we must resize the input image to meet the alignment constraint. When the input image has high frequencies, this can result in sampling artifacts like this:

<img width="1193" height="800" alt="image" src="https://github.com/user-attachments/assets/29b7134e-6223-4b85-8846-cbf298616b46" />

Once browsers support this feature the artifacts should go away!