### PR TITLE
Memory pressure in the GL encoder: a field report, and a question about hooks

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -129,6 +129,18 @@ export interface SparkEncodeOptions {
    * @default 0
    */
   outputBaseLevel?: number
+
+  /**
+   * Encode only levels `[first, last]` of the mip chain, inclusive.
+   *
+   * Levels outside the window cost no draw, no readback and no upload. Use it to fill a
+   * pyramid in more than one pass without re-encoding what a previous pass already wrote.
+   * The source's own mip chain is still generated in full, since level `first` has to exist
+   * before it can be encoded.
+   *
+   * @default the whole chain
+   */
+  levelRange?: [number, number]
 }
 
 /**
@@ -290,6 +302,19 @@ export interface SparkGLTextureResult {
    * Number of mipmap levels
    */
   mipmapCount: number
+
+  /**
+   * How many levels this call actually encoded. Equal to `mipmapCount` unless `levelRange`
+   * narrowed the window — read this, not `mipmapCount`, to know what was written.
+   */
+  levelsWritten?: number
+
+  /** First and last level encoded, in this encode's own numbering. */
+  firstLevel?: number
+  lastLevel?: number
+
+  /** Level of `outputTexture` that `firstLevel` was written to. 0 unless asked otherwise. */
+  outputBaseLevel?: number
 
   /**
    * Whether the texture is encoded in an sRGB format

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -114,7 +114,21 @@ export interface SparkEncodeOptions {
    * - For Spark: pass the `GPUTexture` returned by a prior `encodeTexture()`.
    * - For SparkGL: pass the result object returned by a prior `encodeTexture()`.
    */
-  outputTexture?: GPUTexture | SparkGLTextureResult
+  outputTexture?: GPUTexture | SparkGLReusableOutput
+
+  /**
+   * Write the encode into level `outputBaseLevel`.. of `outputTexture` instead of level 0.
+   *
+   * `outputTexture` must then be this encode shifted up by that many levels: its dimensions
+   * `width << outputBaseLevel` x `height << outputBaseLevel`, at least
+   * `mipmapCount + outputBaseLevel` levels, same format. A mismatch throws rather than
+   * quietly allocating a fresh texture, because the caller asked for a specific destination.
+   *
+   * Sampler state on a caller-supplied `outputTexture` is left untouched.
+   *
+   * @default 0
+   */
+  outputBaseLevel?: number
 }
 
 /**
@@ -228,6 +242,24 @@ export interface SparkGLCreateOptions {
 /**
  * Result object returned by SparkGL.encodeTexture()
  */
+/**
+ * What `outputTexture` actually needs to be.
+ *
+ * A previous `encodeTexture` result satisfies it, which is the common case, but a caller that
+ * owns its own texture — a progressive loader filling one pyramid across several passes — has
+ * no result object to hand back. Requiring the whole result would force it to invent
+ * `byteLength`, `srgb` and a format name that the reuse test never reads.
+ */
+export interface SparkGLReusableOutput {
+  texture: WebGLTexture
+  width: number
+  height: number
+  /** GL internal format the storage was allocated with. */
+  format: number
+  /** Levels the storage HAS, which may exceed what this encode writes. */
+  mipmapCount: number
+}
+
 export interface SparkGLTextureResult {
   /**
    * The compressed WebGL texture

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -348,6 +348,16 @@ export class SparkGL {
    * Call this when you're done encoding textures to free up GPU memory.
    */
   freeTempResources(): void
+
+  /**
+   * Source-copy pool statistics: how many were served from the pool, how many allocated
+   * fresh, and which shapes are currently retained.
+   *
+   * A pool keyed on the wrong thing still reports a high hit rate while handing back
+   * textures of the wrong shape — `srcServed` next to `srcShapes` is what makes that
+   * visible from outside.
+   */
+  getTempResourceStats(): { srcServed: number; srcAllocated: number; srcShapes: { key: string; retained: number }[] }
 }
 
 export default Spark

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -238,6 +238,31 @@ export interface SparkGLCreateOptions {
   cacheTempResources?: boolean
 
   /**
+   * HINT: the largest texture this session expects to encode, in TEXELS (e.g. `4096`).
+   *
+   * A hint and not a limit — an encode larger than it still grows the target rather than
+   * being refused. What it changes is WHEN the target reaches its final size, not how big it
+   * is allowed to get, which is why the name says hint.
+   *
+   * The cached render target holds encoded BLOCKS, so it needs `ceil(size/4)` texels a side,
+   * and it only ever grows. A caller that encodes a small texture before a large one
+   * therefore pays twice: the first encode sizes the target to fit itself, the second finds
+   * it too small, deletes it and allocates again. That is the ordinary shape of a progressive
+   * loader — a small preview, then the full-resolution image — and not something the caller
+   * can reorder its way out of.
+   *
+   * Declaring the ceiling here allocates the target once, at the size the grow path would
+   * have reached anyway. Nothing else changes: the encode drives the viewport and the
+   * readback from the current mip's own block extents, so a target larger than the encode
+   * needs has always been legal.
+   *
+   * Only meaningful together with `cacheTempResources` — without it there is no cached target
+   * to size. An encode larger than the ceiling still grows the target rather than failing:
+   * this is a statement about the common case, not a limit.
+   */
+  hintMaxTmpCacheResolution?: number
+
+  /**
    * Enable verbose logging for debugging.
    * @default false
    */
@@ -373,6 +398,16 @@ export class SparkGL {
    * Call this when you're done encoding textures to free up GPU memory.
    */
   freeTempResources(): void
+
+  /**
+   * Restate `hintMaxTmpCacheResolution` after construction.
+   *
+   * A session that outlives the thing it encodes — one encoder, many models — knows the
+   * device's limits at construction but not the content's, and sizing from the device cap is
+   * the expensive mistake. Takes effect the next time the cached target is allocated or
+   * grown; it deliberately does not reallocate an existing one. `0` restores grow-to-fit.
+   */
+  setHintMaxTmpCacheResolution(resolution: number): void
 
   /**
    * Source-copy pool statistics: how many were served from the pool, how many allocated

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -714,12 +714,28 @@ export class SparkGL {
     // Create or reuse output compressed texture. The caller can pass a previous
     // encodeTexture() result object as options.outputTexture; it is reused only when
     // dimensions, format, and mipmap count match.
-    const reuseOutput =
+    //
+    // options.outputBaseLevel lets that texture be LARGER than this encode: the result is
+    // written starting at that level of the caller's pyramid instead of at level 0, so a
+    // caller filling one pyramid in several passes can reuse it from the first, small pass
+    // instead of having spark allocate a whole pyramid it throws away.
+    const outputBaseLevel = options.outputBaseLevel | 0
+    const reuseOutput = Boolean(
       options.outputTexture &&
-      options.outputTexture.width === width &&
-      options.outputTexture.height === height &&
-      options.outputTexture.mipmapCount === mipmapCount &&
-      options.outputTexture.format === glFormat
+      options.outputTexture.format === glFormat &&
+      options.outputTexture.width === width << outputBaseLevel &&
+      options.outputTexture.height === height << outputBaseLevel &&
+      options.outputTexture.mipmapCount >= mipmapCount + outputBaseLevel
+    )
+    if (options.outputTexture && !reuseOutput && outputBaseLevel !== 0) {
+      throw new Error(
+        `outputBaseLevel ${outputBaseLevel} needs an outputTexture of ` +
+        `${width << outputBaseLevel}x${height << outputBaseLevel} with at least ` +
+        `${mipmapCount + outputBaseLevel} levels in format 0x${glFormat.toString(16)}; got ` +
+        `${options.outputTexture.width}x${options.outputTexture.height} with ` +
+        `${options.outputTexture.mipmapCount} levels in format 0x${(options.outputTexture.format | 0).toString(16)}`
+      )
+    }
 
     const compressedTexture = reuseOutput ? options.outputTexture.texture : gl.createTexture()
     gl.bindTexture(gl.TEXTURE_2D, compressedTexture)
@@ -727,18 +743,25 @@ export class SparkGL {
       gl.texStorage2D(gl.TEXTURE_2D, mipmapCount, glFormat, width, height)
     }
 
-    // Set texture filtering parameters
-    if (generateMipmaps) {
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR)
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
-    } else {
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
-      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
-    }
+    // Sampler state belongs to whoever owns the texture. When the caller supplied it, spark
+    // has already declined to allocate its storage; overwriting its filters and wrap modes
+    // would be the same trespass. A caller reusing its own texture has usually set both from
+    // the source material, and a progressive loader drives TEXTURE_BASE_LEVEL / MIN_LOD on
+    // it between passes -- resetting those mid-stream is visible on screen.
+    if (!reuseOutput) {
+      // Set texture filtering parameters
+      if (generateMipmaps) {
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR)
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+      } else {
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR)
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR)
+      }
 
-    // Set texture wrapping mode (as determined above)
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, glWrapMode)
-    gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, glWrapMode)
+      // Set texture wrapping mode (as determined above)
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, glWrapMode)
+      gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, glWrapMode)
+    }
 
     const bw = Math.ceil(width / 4)
     const bh = Math.ceil(height / 4)
@@ -852,7 +875,7 @@ export class SparkGL {
 
       // Copy pixel buffer object to compressed texture at the curent mip level
       gl.bindTexture(gl.TEXTURE_2D, compressedTexture)
-      gl.compressedTexSubImage2D(gl.TEXTURE_2D, mipLevel, 0, 0, mipWidth, mipHeight, glFormat, mipSize, 0)
+      gl.compressedTexSubImage2D(gl.TEXTURE_2D, mipLevel + outputBaseLevel, 0, 0, mipWidth, mipHeight, glFormat, mipSize, 0)
     }
 
     // Cleanup temporary resources (unless cached)
@@ -900,7 +923,10 @@ export class SparkGL {
       sparkFormat: SparkFormatName[format],
       srgb,
       mipmapCount,
-      byteLength
+      byteLength,
+      // Where this encode landed in the output texture. A caller that reuses the texture
+      // needs it back to know which levels it now owns.
+      outputBaseLevel
     }
 
     return textureObject

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -331,15 +331,26 @@ export class SparkGL {
   dispose() {
     const gl = this.#gl
 
+    // Scratch first, and unconditionally: #programs holds PROMISES (see #loadProgram), so
+    // the loop below used to hand a Promise to gl.deleteProgram and throw before ever
+    // reaching this call -- leaving the buffer, render target and FBO alive for the lifetime
+    // of the context.
+    this.freeTempResources()
+
     if (this.#fullscreenVertexShader) {
       gl.deleteShader(this.#fullscreenVertexShader)
     }
-    for (const program of this.#programs) {
-      gl.deleteProgram(program)
+    for (const entry of this.#programs) {
+      if (!entry) continue
+      // A program may still be compiling. Resolve first, and swallow a rejected load: a
+      // shader that failed to compile has nothing to delete, and dispose() must not be the
+      // place that surfaces it.
+      Promise.resolve(entry).then(
+        (program) => { if (program) gl.deleteProgram(program) },
+        () => {},
+      )
     }
-
-    // Clean up cached temporary resources
-    this.freeTempResources()
+    this.#programs = []
   }
 
   /**

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -305,6 +305,17 @@ export class SparkGL {
   // Cached temporary resources for encodeTexture
   #cachedBuffer = null
   #cachedBufferSize = 0
+  /**
+   * Free source copies, keyed by exact shape ("WxH"). See #acquireSrcTexture.
+   *
+   * Separate from the #cachedTexture8/16 pair below because it answers a different question.
+   * Those are ONE render target that grows to fit the largest encode; this is a set, because
+   * a caller encoding a 4096 and a 256 needs both shapes and neither can stand in for the
+   * other — the encode reads the source with texelFetch at its own dimensions.
+   */
+  #srcPool = new Map()
+  #srcServed = 0
+  #srcAllocated = 0
   #cachedTexture8 = null // For 8-byte per block formats
   #cachedTexture8Width = 0
   #cachedTexture8Height = 0
@@ -351,6 +362,82 @@ export class SparkGL {
       )
     }
     this.#programs = []
+  }
+
+  /**
+   * Take a source-copy texture of this shape from the pool, or make one.
+   *
+   * The source copy is a full RGBA8 mip chain of the image being encoded -- 85 MB for a 4096
+   * -- and it was created and deleted on every call. cacheTempResources reaches the block
+   * render target, the PBO and the FBO, but not this, the largest of the four.
+   *
+   * Keyed on the shape, and a pooled texture is never resized: its storage is IMMUTABLE
+   * (texStorage2D), so a second texStorage2D on it is INVALID_OPERATION and a silent no-op --
+   * the texture would keep its first shape and the encode proceed against the wrong one.
+   *
+   * That is also why the caller must SKIP texStorage2D for a pooled texture rather than let
+   * it no-op harmlessly: even when the shape matches, the call still raises
+   * INVALID_OPERATION into the context's single shared error queue, once per pool hit.
+   * Whoever reads gl.getError() next inherits it and blames their own last call.
+   *
+   * The copy is ALWAYS allocated with a full mip chain, whatever this encode's mipmapCount
+   * is, and that is what lets the key be the shape alone -- mipmapCount follows
+   * options.generateMipmaps rather than the dimensions, so the same WxH can be asked for with
+   * eleven levels or with one. Putting the count in the key would work too, but it makes the
+   * key depend on a per-call flag. The chain costs 4/3 of level 0 on encodes that did not ask
+   * for mips, and buys a key that cannot move.
+   *
+   * At most one texture is retained per shape. freeTempResources() drops them all.
+   */
+  #acquireSrcTexture(width, height) {
+    if (this.#cacheTempResources) {
+      const free = this.#srcPool.get(`${width}x${height}`)
+      if (free && free.length > 0) {
+        this.#srcServed++
+        const texture = free.pop()
+        return { texture, pooled: true }
+      }
+    }
+    this.#srcAllocated++
+    return { texture: this.#gl.createTexture(), pooled: false }
+  }
+
+  /** Return a source copy to the pool, or delete it when pooling is off. */
+  #releaseSrcTexture(texture, width, height) {
+    if (!this.#cacheTempResources) {
+      this.#gl.deleteTexture(texture)
+      return
+    }
+    const key = `${width}x${height}`
+    let free = this.#srcPool.get(key)
+    if (!free) {
+      free = []
+      this.#srcPool.set(key, free)
+    }
+    // One per shape. encodeTexture holds exactly one source copy at a time, so a second is
+    // only ever reachable through concurrent calls -- and retaining an 85 MB texture on the
+    // chance of an overlap is the wrong trade for the thing this pool exists to reduce.
+    if (free.length >= 1) {
+      this.#gl.deleteTexture(texture)
+      return
+    }
+    free.push(texture)
+  }
+
+  /**
+   * How the source-copy pool is doing: `served` from the pool, `allocated` fresh, and the
+   * shapes currently retained.
+   *
+   * Worth exposing rather than keeping internal: a pool that is keyed wrongly still reports
+   * a high hit rate while handing back textures of the wrong shape, and served-vs-shapes is
+   * what makes that visible from outside.
+   */
+  getTempResourceStats() {
+    return {
+      srcServed: this.#srcServed,
+      srcAllocated: this.#srcAllocated,
+      srcShapes: [...this.#srcPool.entries()].map(([key, free]) => ({ key, retained: free.length })),
+    }
   }
 
   /**
@@ -445,6 +532,31 @@ export class SparkGL {
       gl.deleteFramebuffer(this.#cachedFbo)
       this.#cachedFbo = null
     }
+
+    for (const free of this.#srcPool.values()) {
+      for (const texture of free) gl.deleteTexture(texture)
+    }
+    this.#srcPool.clear()
+  }
+
+  /**
+   * Levels a complete chain has for this size, down to a 4x4 tail.
+   *
+   * One definition, used by the encode AND by the source copy, which no longer agree by
+   * accident: the copy is always allocated with the full chain (see #acquireSrcTexture) while
+   * the encode may be asked for a single level.
+   */
+  static #fullMipCount(width, height) {
+    const MIN_MIP_SIZE = 4
+    let count = 1
+    let w = width
+    let h = height
+    while (w > MIN_MIP_SIZE || h > MIN_MIP_SIZE) {
+      count++
+      w = Math.max(1, Math.floor(w / 2))
+      h = Math.max(1, Math.floor(h / 2))
+    }
+    return count
   }
 
   #isFormatSupported(format) {
@@ -606,27 +718,26 @@ export class SparkGL {
 
     // Determine mipmap count
     const generateMipmaps = options.generateMipmaps || options.mips
-    let mipmapCount = 1
-    if (generateMipmaps) {
-      const MIN_MIP_SIZE = 4
-      let w = width
-      let h = height
-      while (w > MIN_MIP_SIZE || h > MIN_MIP_SIZE) {
-        mipmapCount++
-        w = Math.max(1, Math.floor(w / 2))
-        h = Math.max(1, Math.floor(h / 2))
-      }
-    }
+    const mipmapCount = generateMipmaps ? SparkGL.#fullMipCount(width, height) : 1
 
-    // Create input texture
-    const srcTexture = gl.createTexture()
+    // Create input texture (pooled by shape -- see #acquireSrcTexture)
+    const { texture: srcTexture, pooled: srcPooled } = this.#acquireSrcTexture(width, height)
     gl.bindTexture(gl.TEXTURE_2D, srcTexture)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, glWrapMode)
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, glWrapMode)
 
-    gl.texStorage2D(gl.TEXTURE_2D, mipmapCount, gl.RGBA8, width, height)
+    // The FULL chain, not this encode's mipmapCount -- see #acquireSrcTexture for why the
+    // level count is deliberately not part of the pool key.
+    //
+    // A pooled texture already has exactly this storage -- the pool is keyed on the shape,
+    // never resizes, and every entry was allocated with the same rule -- and storage is
+    // immutable, so asking again is INVALID_OPERATION and a no-op. Harmless to the pixels,
+    // not harmless to the error queue: see #acquireSrcTexture.
+    if (!srcPooled) {
+      gl.texStorage2D(gl.TEXTURE_2D, SparkGL.#fullMipCount(width, height), gl.RGBA8, width, height)
+    }
     gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, width, height, gl.RGBA, gl.UNSIGNED_BYTE, image)
 
 
@@ -698,7 +809,7 @@ export class SparkGL {
       gl.deleteShader(fsShader)
       gl.deleteProgram(flipProgram)
       gl.deleteFramebuffer(flipFbo)
-      gl.deleteTexture(srcTexture)
+      this.#releaseSrcTexture(srcTexture, width, height)
 
       encodeSrcTexture = flippedTexture
     }
@@ -884,7 +995,14 @@ export class SparkGL {
       gl.deleteBuffer(dstBuffer)
       gl.deleteFramebuffer(fbo)
     }
-    gl.deleteTexture(encodeSrcTexture)
+    // Only the pooled source copy goes back to the pool. Under flipY the encode read from
+    // `flippedTexture`, which has IMMUTABLE storage and could never be re-specified for a
+    // later encode -- pooling it would be the silent-no-op bug this pool is keyed to avoid.
+    if (encodeSrcTexture === srcTexture) {
+      this.#releaseSrcTexture(encodeSrcTexture, width, height)
+    } else {
+      gl.deleteTexture(encodeSrcTexture)
+    }
 
     // Restore GL state
     gl.bindFramebuffer(gl.FRAMEBUFFER, savedState.framebuffer)

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -322,6 +322,9 @@ export class SparkGL {
   #cachedTexture16 = null // For 16-byte per block formats
   #cachedTexture16Width = 0
   #cachedTexture16Height = 0
+  // Block-grid side for the cached render target's first allocation, from
+  // options.hintMaxTmpCacheResolution. 0 = size it to the first encode and grow.
+  #maxCacheBlocks = 0
   #cachedFbo = null
 
   constructor(gl, options = {}) {
@@ -332,6 +335,9 @@ export class SparkGL {
     this.#verbose = options.verbose ?? false
     this.#validateShaders = options.validateShaders ?? false
     this.#cacheTempResources = options.cacheTempResources ?? false
+    // In TEXELS at the API boundary -- that is the number a caller knows about its own images
+    // -- converted once to the block grid the render target is actually measured in.
+    this.setHintMaxTmpCacheResolution(options.hintMaxTmpCacheResolution ?? 0)
     this.#supportedFormats = detectWebGLFormats(gl, this.#verbose)
 
     // Handle preload option
@@ -414,6 +420,24 @@ export class SparkGL {
     return { texture: gl.createTexture(), pooled: false }
   }
 
+  /**
+   * Restate the hint after construction, for a session that outlives what it encodes: it
+   * knows the DEVICE's limits when it is built and the CONTENT's only later, and sizing from
+   * the device cap is the expensive mistake.
+   *
+   * Applies the next time the target is allocated or grown, which is soon enough -- the
+   * target is lazy. Deliberately does not reallocate an existing one: an encode may be
+   * reading it.
+   *
+   * @param {number} resolution - Largest texture to be encoded, in texels. 0 = grow to fit.
+   */
+  setHintMaxTmpCacheResolution(resolution) {
+    if (resolution > 0 && !Number.isFinite(resolution)) {
+      throw new Error(`hintMaxTmpCacheResolution must be a finite number of texels, got ${resolution}`)
+    }
+    this.#maxCacheBlocks = resolution > 0 ? Math.ceil(resolution / 4) : 0
+  }
+
   /** Return a source copy to the pool, or delete it when pooling is off. */
   #releaseSrcTexture(texture, width, height) {
     if (!this.#cacheTempResources) {
@@ -459,6 +483,7 @@ export class SparkGL {
    * @param {boolean|string[]} options.preload - Whether to preload all encoder pipelines, or an array of format names to preload (false by default).
    * @param {boolean} options.verbose - Whether to enable verbose logging (false by default).
    * @param {boolean} options.cacheTempResources - Whether to cache temporary resources for reuse across encodeTexture calls (false by default).
+   * @param {number} options.hintMaxTmpCacheResolution - HINT: the largest texture this session expects to encode, in texels. The cached render target is allocated at that size on its first use instead of growing to fit, which removes the reallocation a small-then-large sequence would otherwise cause. It is not a limit -- an encode larger than the hint still grows the target rather than failing. Only meaningful with cacheTempResources.
    * @returns {SparkGL} A new SparkGL instance.
    */
   static create(gl, options = {}) {
@@ -917,6 +942,11 @@ export class SparkGL {
 
     // Create or reuse render target (uint) texture.
     // Need different textures for 8-byte and 16-byte per block formats.
+    //
+    // allocW/allocH honour the size hint: with one declared, the target is allocated at that
+    // size the first time instead of growing into it over several encodes.
+    const allocW = cacheTempResources ? Math.max(bw, this.#maxCacheBlocks) : bw
+    const allocH = cacheTempResources ? Math.max(bh, this.#maxCacheBlocks) : bh
     let mipDstTexture
 
     if (blockSize === 8) {
@@ -930,11 +960,11 @@ export class SparkGL {
         }
         mipDstTexture = gl.createTexture()
         gl.bindTexture(gl.TEXTURE_2D, mipDstTexture)
-        gl.texStorage2D(gl.TEXTURE_2D, 1, glUintFormat, bw, bh)
+        gl.texStorage2D(gl.TEXTURE_2D, 1, glUintFormat, allocW, allocH)
         if (cacheTempResources) {
           this.#cachedTexture8 = mipDstTexture
-          this.#cachedTexture8Width = bw
-          this.#cachedTexture8Height = bh
+          this.#cachedTexture8Width = allocW
+          this.#cachedTexture8Height = allocH
         }
       }
     } else {
@@ -948,11 +978,11 @@ export class SparkGL {
         }
         mipDstTexture = gl.createTexture()
         gl.bindTexture(gl.TEXTURE_2D, mipDstTexture)
-        gl.texStorage2D(gl.TEXTURE_2D, 1, glUintFormat, bw, bh)
+        gl.texStorage2D(gl.TEXTURE_2D, 1, glUintFormat, allocW, allocH)
         if (cacheTempResources) {
           this.#cachedTexture16 = mipDstTexture
-          this.#cachedTexture16Width = bw
-          this.#cachedTexture16Height = bh
+          this.#cachedTexture16Width = allocW
+          this.#cachedTexture16Height = allocH
         }
       }
     }

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -390,16 +390,28 @@ export class SparkGL {
    * At most one texture is retained per shape. freeTempResources() drops them all.
    */
   #acquireSrcTexture(width, height) {
+    const gl = this.#gl
     if (this.#cacheTempResources) {
       const free = this.#srcPool.get(`${width}x${height}`)
       if (free && free.length > 0) {
         this.#srcServed++
         const texture = free.pop()
+        // Hand back a texture in the state a FRESH one would be in.
+        //
+        // TEXTURE_BASE_LEVEL is the one parameter the encode loop dirties and nobody
+        // repairs: it is set to the level being encoded and left at the last one. A freshly
+        // created texture starts at 0, which is why nothing here ever had to set it --
+        // pooling is what breaks that assumption. Left at 10, the next generateMipmap
+        // sources from level 10 and derives nothing below it, so levels 1..9 keep the
+        // PREVIOUS image's content. Clearing them would not help: they are regenerated, but
+        // only from BASE_LEVEL up.
+        gl.bindTexture(gl.TEXTURE_2D, texture)
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_BASE_LEVEL, 0)
         return { texture, pooled: true }
       }
     }
     this.#srcAllocated++
-    return { texture: this.#gl.createTexture(), pooled: false }
+    return { texture: gl.createTexture(), pooled: false }
   }
 
   /** Return a source copy to the pool, or delete it when pooling is off. */
@@ -964,14 +976,27 @@ export class SparkGL {
     // Setup rendering state
     gl.useProgram(program)
 
-    // Encode each mipmap level
-    for (let mipLevel = 0; mipLevel < mipmapCount; mipLevel++) {
+    // Encode each mipmap level. options.levelRange = [first, last] restricts that to a
+    // window; a skipped level costs no draw, no readback and no upload. The point is to stop
+    // re-encoding levels the caller already has -- filling one pyramid in two passes
+    // otherwise re-encodes the whole chain on the second and throws most of it away.
+    //
+    // The source's chain is still generated in full above: level `first` has to exist first.
+    const firstLevel = Math.max(0, options.levelRange ? options.levelRange[0] | 0 : 0)
+    const lastLevel = Math.min(mipmapCount - 1, options.levelRange ? options.levelRange[1] | 0 : mipmapCount - 1)
+    if (firstLevel > lastLevel) {
+      throw new Error(`levelRange [${firstLevel}, ${lastLevel}] selects no level of a ${mipmapCount}-level encode`)
+    }
+    let levelsWritten = 0
+
+    for (let mipLevel = firstLevel; mipLevel <= lastLevel; mipLevel++) {
       const mipWidth = Math.max(1, Math.floor(width >> mipLevel))
       const mipHeight = Math.max(1, Math.floor(height >> mipLevel))
       const mipBw = Math.ceil(mipWidth / 4)
       const mipBh = Math.ceil(mipHeight / 4)
       const mipSize = blockSize * mipBw * mipBh
       byteLength += mipSize
+      levelsWritten++
 
       // Bind input texture at current mip level
       gl.bindTexture(gl.TEXTURE_2D, encodeSrcTexture)
@@ -1042,8 +1067,12 @@ export class SparkGL {
       srgb,
       mipmapCount,
       byteLength,
-      // Where this encode landed in the output texture. A caller that reuses the texture
-      // needs it back to know which levels it now owns.
+      // Which levels this encode actually wrote, and where they landed in the output
+      // texture. Under levelRange these are not mipmapCount levels starting at 0, and a
+      // caller that reads mipmapCount alone would believe it has levels nobody encoded.
+      levelsWritten,
+      firstLevel,
+      lastLevel,
       outputBaseLevel
     }
 


### PR DESCRIPTION
Part of this experiment was done with Claude, so I dont expect you use the code as is at all, it's more an explanation about what I found.

Again thank you for spark.js it's great 🙏

## What this is

Not a merge request so much as a **field report with code attached**. I drive SparkGL from a
progressive texture loader in a 3D viewer, and getting there needed five changes to the
encoder. A couple are plain bugs; the rest are shaped by my one use case, and I suspect the
better answer for upstream is not these patches but a few hooks. More on that at the end.

Everything below is measured. Numbers come from one asset (21 × 4096² textures, 42 encodes,
BC7) on an Apple M4 Max through ANGLE Metal, over the real viewer path. They come from a
GL-level census of every texture created, kept and written during a load, plus a render gate
that compares actual pixels against an uncompressed run. Deliberately not from the encoder's
own accounting, since the encoder is the thing under test: I've had a run report 4.00× and zero
fallbacks while drawing a visibly wrong image.

Happy to split this up, drop the parts that don't fit, or just close it and keep the discussion.

## How I use SparkGL

Textures load in two passes. Pass 1 decodes a small preview (256²) so the model is on screen in
under a second; pass 2 decodes the full-resolution image. **Both passes write into the same GL
texture**, one immutable BC7 pyramid per texture, filled from the small end first and then from
the top, so there is never a texture swap and never a visible pop.

That shape is what most of these changes are about: the caller owns the destination pyramid and
fills it across several encodes.

For context on the payoff: **448 MB of texture memory instead of 1792 MB** (4.00×), at 49.5 dB
(colour) / 48.5 dB (normal) / 44.5 dB (packed data) PSNR, for +25 to 32 ms per 4K texture.

That ratio is steady state, though, and it says nothing about the load itself. With the
intermediate render target sized in texels rather than blocks (before #43), one of these loads
allocated and freed on the order of **7 GB** of scratch to produce those 448 MB. Most of what
follows is about that gap rather than about the ratio.

## The changes

### 1. `dispose()` never freed the cached scratch

`#programs` holds **promises** of programs, so `gl.deleteProgram(promise)` throws, and it threw
*before* reaching the `freeTempResources()` call at the end of the function. On a session that
had encoded one 4096 texture with `cacheTempResources` on, that left the scratch render target
alive for the lifetime of the context.

Fixed by freeing the scratch first and unconditionally, and by resolving each program before
deleting it. This one is just a bug; take it in whatever form you like.

### 2. Let the caller own the output pyramid: `outputBaseLevel`, `levelRange`

`outputTexture` already lets a caller hand back a previous result, but it requires the encode to
match the texture exactly. My pass 1 encodes a 256² source into levels 4..10 of a 4096 pyramid,
so it can't take that path at all: spark allocates a full pyramid I immediately throw away.

- **`outputBaseLevel`** writes the result starting at level N of the caller's texture instead of
  level 0.
- **`levelRange: [first, last]`** encodes only a window. On my pass 2 that skips **seven of
  eleven levels**, the ones pass 1 already wrote. A skipped level costs no draw, no readback
  and no upload.
- The result now reports `levelsWritten` / `firstLevel` / `lastLevel`, because under a window
  those are *not* `mipmapCount` levels starting at 0, and a caller reading `mipmapCount` alone
  would think it has levels nobody encoded.
- `outputTexture` is typed as a new `SparkGLReusableOutput` (5 fields) rather than a whole
  `SparkGLTextureResult`: a caller that owns its own texture has no result object to hand back,
  and shouldn't have to invent `byteLength`, `srgb` and a format name the reuse test never reads.

One behaviour change to flag: sampler state on a caller-supplied `outputTexture` is now left
alone. That is **specific to my use case**. My loader drives `TEXTURE_BASE_LEVEL` and
`TEXTURE_MIN_LOD` on that texture between the two passes, so it needs them preserved across an
encode. I doubt that generalises, and it's probably the wrong default for everyone else.

### 3. Pool the temporary source copy

This is the big one, and the most likely to be worth your attention regardless of what you think
of my patch.

`encodeTexture` creates a full RGBA8 mip chain of the source, **85 MB for a 4096²**, and deletes
it on every call. `cacheTempResources` reaches the block render target, the PBO and the FBO, but
not this, which is the largest of the four.

Measured over one load of the asset above:

| | `cacheTempResources` only | + source-copy pool |
|---|---|---|
| transient allocation | 2136 MB | **102 MB** |
| GL objects allocated by the encoder | 178 | **11** |
| peak live texture memory | 565.4 MB | 565.7 MB |

**Note the last row.** The peak does not move: the largest single encode dominates it either
way. This buys churn, not headroom, which I still think is worth having, since rapid
create/delete of multi-megabyte GPU objects is its own hazard on some drivers, and 178 to 11 is
a different kind of number from a memory saving.

The pool is keyed on the shape, retains at most one texture per shape, and `freeTempResources()`
drops them all. On my load: **41 of 44 source copies served from the pool (93%), 3 allocated**,
one per distinct shape, which is the check that the key is right rather than merely lucky.

Two details that turned out to matter more than expected:

**The source copy is always allocated with a full mip chain**, even when the encode asked for
one level. `mipmapCount` follows `options.generateMipmaps` rather than the dimensions, so the
same WxH can be asked for with eleven levels or with one, and under immutable storage a
one-level texture can't be grown to fit an eleven-level encode. Putting the level count in the
key also works (I tried it) but then the key depends on a per-call flag. The full chain costs
4/3 of level 0 (85.33 MiB against 64.00 for a 4096²) on encodes that didn't want mips, and buys
a key that can't move. **This trade is the one I'm least sure about**, and with
`generateMipmaps: false` being the documented default it's a real cost for other callers, so it
may well be the wrong call for upstream.

**A pooled texture must skip `texStorage2D`, not let it no-op.** Since #44 the source has
immutable storage, so re-specifying it is `INVALID_OPERATION` and does nothing. Harmless to the
pixels, since the pool is keyed on the shape and the storage it finds is the storage it wanted,
but it does put an error in the queue: I measured **41 spurious `INVALID_OPERATION` per load**,
one per pool hit. Since a WebGL context has a single shared error queue, that can be misleading
for anyone calling `gl.getError()` afterwards, who has no way to tell whose error it is. Only
relevant here because the pool is what creates the repeats, but it seemed worth mentioning,
since a caller reading the queue can end up chasing the wrong thing.

Worth noting that #45 overlaps with this from the other end. Under `flipY` the encode currently
reads from a second, immutable texture, and my pool deliberately leaves that one alone, since
pooling an immutable texture allocated per call is exactly the trap described above. If #45
lands, that branch disappears and the pool gets simpler, and it removes an intermediate
allocation on its own terms.

### 4. `TEXTURE_BASE_LEVEL` is left dirty by the encode loop

The loop sets `TEXTURE_BASE_LEVEL` per level and leaves it at the last one. A freshly created
texture starts at 0, so nothing ever had to reset it, which is exactly why it only surfaces
once a texture is reused.

Left at 10, the next `generateMipmap` sources from level 10 and derives nothing below it, so
levels 1..9 keep the *previous* image's content. Clearing them wouldn't help: they are
regenerated, but only from `BASE_LEVEL` up.

I reset it when handing a texture back from the pool. This is **only reachable because I pool**,
so it's arguably custom to my use case too, though it would be latent for any caller that reuses
a source texture, which is why it might be worth doing at the loop instead.

### 5. Size the scratch from the content, not by growing into it: `hintMaxTmpCacheResolution`

The cached block render target only ever grows (`cachedWidth < bw`). My two passes hit the bad
order every single time: pass 1 (256² to 64² blocks) sizes it, pass 2 (4096² to 1024² blocks)
finds it too small, deletes it and allocates again.

`hintMaxTmpCacheResolution` declares the largest texture the session expects to encode, in
texels, and the target is allocated at that size the first time instead of growing into it.
Nothing else changes: the encode drives the viewport and the readback from the current mip's
own block extents, so a target larger than the encode needs has always been legal. It's what the
grow path produces one encode later anyway. Result on my load: **block render targets allocated
3 to 1**, encoder allocations 12 to 11, peak unchanged. It avoids reallocations, that's all.

**It's a hint, and named as one**: an encode larger than it still grows the target rather than
being refused. Naming it `maxTmpCacheResolution` first was a mistake, because it read as a cap
being enforced, which it never was. What it changes is *when* the target reaches its final size,
not how big it may get.

`setHintMaxTmpCacheResolution()` restates it after construction. I need that because my encoder
is created at viewer start-up, before any model is loaded: at construction the only number
available is the *device's* cap, and that's the wrong one to size from. With a device cap of
8192 while my assets top out at 4096, the target is allocated at 2048² RGBA32UI instead of 1024²
(64 MB against 16 MB) to save two allocations. Passing the content's own maximum instead gives
the numbers above.

## Things I'm not sure about

Listing my own warts so you don't have to find them:

- **`outputTexture` throws only when `outputBaseLevel !== 0`.** With the default of 0, a
  wrong-shaped `outputTexture` still silently allocates a fresh texture (the pre-existing
  behaviour). Same caller mistake, two different outcomes, depending on an unrelated option. I
  left it that way to avoid changing existing behaviour, but it's hard to defend.
- **`levelRange` clamps silently** (`[0, 99]` becomes `[0, 10]`) while `outputBaseLevel` throws.
  Two neighbouring options taking opposite stances on the same class of caller error. Only
  `first > last` throws.
- **`getTempResourceStats()`** is diagnostics, not memory reduction. I use it to check the pool
  from outside, since a pool keyed on the wrong thing still reports a healthy hit rate while
  handing back the wrong shape. Easy to drop if it's not your kind of API.
- **The always-full-chain source copy** (see above) is a real cost for `generateMipmaps: false`
  callers, which is the documented default.

## What I actually think the answer is

I forked mainly to find out **what I needed to hook** in order to customise the behaviour, and
the fork is the answer to that question rather than a proposal in itself.

Now that I know, I think most of this could be exposed as a small number of extension points
rather than merged as behaviour: somewhere to plug in an allocation strategy for the temporary
resources (the pool being one implementation among others), and somewhere to control how the
compressed result lands in the destination's mip levels. Neither seems to need much added
complexity, and the defaults would do exactly what SparkGL does today, so nothing changes for
existing callers, and someone with an unusual pipeline can adapt it without forking.

That would also make the two questionable calls above go away: the full-chain source copy and
the sampler-state change are only defensible for my pipeline, and they'd belong on my side of
such a hook rather than in the library.

Branch: `cedricpinson/spark.js:reduce-memory-pressure`, five commits, each with its reasoning in
the message. Happy to reshape any of it toward the hook approach if that's the direction you'd
prefer.
