### PR TITLE
Fix dispose implementation in both Spark and SparkGL.

### DIFF
--- a/API.md
+++ b/API.md
@@ -241,6 +241,8 @@ spark.freeTempResources()
 
 Destroys the Spark instance and all associated GPU resources.
 
+For `SparkGL`, `dispose()` is asynchronous and resolves once any programs still being compiled have been deleted. Awaiting it is optional.
+
 **Example:**
 
 ```js

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -284,8 +284,9 @@ export class SparkGL {
 
   /**
    * Destroys the SparkGL instance and all associated GPU resources.
+   * Resolves once any programs still being compiled have been deleted.
    */
-  dispose(): void
+  dispose(): Promise<void>
 
   /**
    * Load an image and encode it to a compressed WebGL texture.

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -297,6 +297,7 @@ export class SparkGL {
   #gl
   #supportedFormats
   #programs = []
+  #disposed = false
   #verbose = false
   #validateShaders = false
   #encodeCounter = 0
@@ -328,18 +329,32 @@ export class SparkGL {
       this.#preloadShaders(options.preload)
     }
   }
-  dispose() {
+  async dispose() {
     const gl = this.#gl
-
-    if (this.#fullscreenVertexShader) {
-      gl.deleteShader(this.#fullscreenVertexShader)
-    }
-    for (const program of this.#programs) {
-      gl.deleteProgram(program)
-    }
+    this.#disposed = true
 
     // Clean up cached temporary resources
     this.freeTempResources()
+
+    // #programs holds promises (see #loadProgram), so a program may still be compiling.
+    // Wait for each one before deleting it, and ignore rejected loads: a shader that failed
+    // to compile has nothing to delete and already reported its error to the caller.
+    const programs = this.#programs
+    this.#programs = []
+    for (const entry of programs) {
+      if (!entry) continue
+      try {
+        const program = await entry
+        gl.deleteProgram(program)
+      } catch {
+        // Nothing to delete.
+      }
+    }
+
+    if (this.#fullscreenVertexShader) {
+      gl.deleteShader(this.#fullscreenVertexShader)
+      this.#fullscreenVertexShader = null
+    }
   }
 
   /**
@@ -479,6 +494,11 @@ export class SparkGL {
       }
 
       const fragmentShaderSource = await loadShaderSource(shaderFile)
+
+      // dispose() may have run while the source was loading; the vertex shader is gone.
+      if (this.#disposed) {
+        throw new Error("SparkGL was disposed while loading program for format: " + SparkFormatName[format])
+      }
 
       const fragmentShader = createShader(gl, gl.FRAGMENT_SHADER, fragmentShaderSource, this.#validateShaders)
       const program = createProgram(gl, this.#fullscreenVertexShader, fragmentShader, this.#validateShaders)

--- a/src/spark.js
+++ b/src/spark.js
@@ -303,21 +303,17 @@ class Spark {
   }
 
   dispose() {
-    for (const pipeline of this.#pipelines) {
-      pipeline.destroy()
-    }
-    this.#mipmapPipeline.destroy()
-    this.#resizePipeline.destroy()
-    this.#flipYPipeline.destroy()
-    this.#detectChannelCountPipeline.destroy()
+    // Pipelines and samplers are not destroyable in WebGPU; drop references and let GC reclaim them.
+    this.#pipelines = []
 
-    this.#defaultSampler.destroy()
     for (let i = 0; i < 3; i++) {
       this.#uniformBuffer[i].destroy()
     }
-    this.#querySet.destroy()
-    this.#queryBuffer.destroy()
-    this.#queryReadbackBuffer.destroy()
+    if (this.#querySet) {
+      this.#querySet.destroy()
+      this.#queryBuffer.destroy()
+      this.#queryReadbackBuffer.destroy()
+    }
 
     this.freeTempResources()
   }


### PR DESCRIPTION
Spark's `dispose()` was always throwing trying to destroy objects that don't have a destroy method.

SparkGL's `dispose()` did not wait for program promises, so it could pass a promise to `gl.deleteProgram`. Now it waits for programs to compile, so it's async, and adds a disposed flag so that attempts to compile a program after dispose immediately fail.

This should address one of the main issues raised in: https://github.com/Ludicon/spark.js/pull/46