### PR TITLE
Add minSize and allocateMipmas options to cachedTempResources.

### DIFF
--- a/API.md
+++ b/API.md
@@ -63,7 +63,7 @@ Creates a new Spark instance for WebGPU.
 - `device` (`GPUDevice`) - WebGPU device with required features enabled
 - `options` (`Object`, optional) - Configuration options:
   - `preload` (`boolean` or `string[]`, default: `false`) - Whether to preload all or a subset of the encoder pipelines. Pipelines that are not preloaded are compiled on-demand when first used.
-  - `cacheTempResources` (`boolean`, default: `false`) - Whether to cache temporary resources for reuse across `encodeTexture` calls. Cached resources grow to fit the largest encode and are freed by `freeTempResources()` or `dispose()`. Improves performance when encoding multiple textures.
+  - `cacheTempResources` (`boolean` or `object`, default: `false`) - Whether to cache temporary resources for reuse across `encodeTexture` calls. Cached resources grow to fit the largest encode and are freed by `freeTempResources()` or `dispose()`. Improves performance when encoding multiple textures. Pass an object to enable caching and control the allocation (see [Resource Caching](#resource-caching)).
   - `verbose` (`boolean`, default: `false`) - Enable verbose logging for debugging.
   - `useTimestampQueries` (`boolean`, default: `false`) - Enable GPU timestamp queries for performance profiling (requires `timestamp-query` feature and enabling unsafe WebGPU features in the browser).
 
@@ -104,7 +104,7 @@ Creates a new SparkGL instance for WebGL2.
     - `false` - Load shaders on-demand
     - `true` - Preload all supported formats
     - `string[]` - Array of format names to preload (e.g., `["bc7", "astc"]`)
-  - `cacheTempResources` (`boolean`, default: `false`) - Whether to cache temporary resources for reuse across `encodeTexture` calls. Cached resources grow to fit the largest encode and are freed by `freeTempResources()` or `dispose()`. Improves performance when encoding multiple textures.
+  - `cacheTempResources` (`boolean` or `object`, default: `false`) - Whether to cache temporary resources for reuse across `encodeTexture` calls. Cached resources grow to fit the largest encode and are freed by `freeTempResources()` or `dispose()`. Improves performance when encoding multiple textures. Pass an object to enable caching and control the allocation (see [Resource Caching](#resource-caching)).
   - `verbose` (`boolean`, default: `false`) - Enable verbose logging for debugging.
   - `validateShaders` (`boolean`, default: `false`) - Enable WebGL shader validation. Only enable thsi for debuggigng, as it disables async shader compilation.
 
@@ -312,7 +312,7 @@ const spark = SparkGL.create(gl, { preload: ["rgb", "rg", "r"] })
 
 ### Resource Caching
 
-Enable resource caching for batch encoding:
+Each `encodeTexture()` call needs a few temporary GPU resources: a copy of the source image (with mipmaps, if requested), an intermediate buffer or render target for the encoded blocks, and a readback buffer. By default these are allocated and freed on every call. When encoding many textures, enable `cacheTempResources` to keep them alive across calls:
 
 ```js
 const spark = await Spark.create(device, { cacheTempResources: true })
@@ -323,6 +323,23 @@ const textures = await Promise.all(
 // Free cached resources
 spark.freeTempResources()
 ```
+
+Cached resources are allocated lazily, the first time an encode needs them, and are sized by that encode. A later encode that is larger, or that needs more mipmap levels, reallocates them; a smaller one reuses them. They are released by `freeTempResources()` or `dispose()`.
+
+#### Sizing the cache
+
+Because the cache only grows on demand, a sequence of encodes of increasing size (for example 64, 128, 256, 512) reallocates at every step. To avoid this, pass an object instead of `true` to control how the cached resources are allocated. Both fields are optional and behave the same in `Spark` and `SparkGL`:
+
+```js
+const spark = await Spark.create(device, {
+  cacheTempResources: { minSize: 2048, allocateMipmaps: true }
+})
+```
+
+- `minSize` (`number`, default: `0`) - Minimum width and height, in texels, that cached resources are allocated for. With `minSize: 512` the sequence above allocates once, on the first encode. Encodes larger than `minSize` still grow the cache. The value is clamped to the device's maximum texture size.
+- `allocateMipmaps` (`boolean`, default: `false`) - Allocate cached resources with a full mip chain even if the encode that triggers the allocation does not generate mipmaps. By default the chain is only allocated when the triggering encode requests mipmaps, so callers that never use mipmaps (for example tile renderers) don't pay for it. Callers that mix mipmapped and non-mipmapped encodes can set this to avoid a reallocation the first time mipmaps are requested.
+
+Memory cost for `minSize = N` is roughly `N² × 4` bytes for the RGBA8 source copy (×4/3 with mipmaps), plus `(N/4)² × 16` bytes per block render target or output buffer. For `N = 4096` that is 64–85 MB plus 16 MB.
 
 ### Verbose Logging
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,27 @@
 /**
  * Options for initializing Spark (WebGPU) encoder
  */
+/**
+ * Options controlling how temporary resources are cached across encodeTexture calls.
+ */
+export interface SparkCacheOptions {
+  /**
+   * Minimum width and height (in texels) that cached resources are allocated for, so that a
+   * sequence of encodes of increasing size up to this value does not reallocate them.
+   * Encodes larger than this still grow the cache. Clamped to the device's maximum texture size.
+   * @default 0 (size of the encode that triggers the allocation)
+   */
+  minSize?: number
+
+  /**
+   * Allocate cached resources with a full mip chain even when the encode that triggers the
+   * allocation does not generate mipmaps. Avoids a reallocation the first time a mipmapped
+   * encode is requested, at the cost of ~33% more memory for the source texture.
+   * @default false
+   */
+  allocateMipmaps?: boolean
+}
+
 export interface SparkCreateOptions {
   /**
    * Whether to preload all encoder pipelines or an array of format names to preload.
@@ -16,9 +37,10 @@ export interface SparkCreateOptions {
   /**
    * Whether to cache temporary resources for reuse across encodeTexture calls.
    * Improves performance when encoding multiple textures, but uses more GPU memory.
+   * Pass an object to enable caching and control how the resources are allocated.
    * @default false
    */
-  cacheTempResources?: boolean
+  cacheTempResources?: boolean | SparkCacheOptions
 
   /**
    * Enable verbose logging for debugging.
@@ -207,9 +229,10 @@ export interface SparkGLCreateOptions {
 
   /**
    * Whether to cache temporary resources for reuse across encodeTexture calls.
+   * Pass an object to enable caching and control how the resources are allocated.
    * @default false
    */
-  cacheTempResources?: boolean
+  cacheTempResources?: boolean | SparkCacheOptions
 
   /**
    * Enable verbose logging for debugging.

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -1,6 +1,6 @@
 // WebGL implementation of spark.js texture compression API
 import glslShaders from "./shaders/glsl-shaders.js"
-import { assert, loadImage, loadImageFromBlob } from "./utils.js"
+import { assert, loadImage, loadImageFromBlob, parseCacheTempResources } from "./utils.js"
 
 const SparkFormat = {
   ASTC_4x4_RGB: 0,
@@ -293,6 +293,21 @@ function createProgram(gl, vertexShader, fragmentShader, validate) {
   return program
 }
 
+// Let's not waste time generating mips below this size:
+const MIN_MIP_SIZE = 4
+
+function computeMipmapCount(width, height) {
+  let mipmapCount = 1
+  let w = width
+  let h = height
+  while (w > MIN_MIP_SIZE || h > MIN_MIP_SIZE) {
+    mipmapCount++
+    w = Math.max(1, Math.floor(w / 2))
+    h = Math.max(1, Math.floor(h / 2))
+  }
+  return mipmapCount
+}
+
 export class SparkGL {
   #gl
   #supportedFormats
@@ -303,6 +318,8 @@ export class SparkGL {
   #encodeCounter = 0
   #fullscreenVertexShader
   #cacheTempResources = false
+  #cacheMinSize = 0 // Minimum width/height cached resources are allocated for
+  #cacheAllocateMipmaps = false // Allocate a full mip chain for cached resources
   // Cached temporary resources for encodeTexture
   #cachedBuffer = null
   #cachedBufferSize = 0
@@ -325,7 +342,10 @@ export class SparkGL {
     this.#gl = gl
     this.#verbose = options.verbose ?? false
     this.#validateShaders = options.validateShaders ?? false
-    this.#cacheTempResources = options.cacheTempResources ?? false
+    const cache = parseCacheTempResources(options.cacheTempResources)
+    this.#cacheTempResources = cache.enabled
+    this.#cacheMinSize = Math.min(cache.minSize, gl.getParameter(gl.MAX_TEXTURE_SIZE))
+    this.#cacheAllocateMipmaps = cache.allocateMipmaps
     this.#supportedFormats = detectWebGLFormats(gl, this.#verbose)
 
     // Handle preload option
@@ -628,17 +648,7 @@ export class SparkGL {
 
     // Determine mipmap count
     const generateMipmaps = options.generateMipmaps || options.mips
-    let mipmapCount = 1
-    if (generateMipmaps) {
-      const MIN_MIP_SIZE = 4
-      let w = width
-      let h = height
-      while (w > MIN_MIP_SIZE || h > MIN_MIP_SIZE) {
-        mipmapCount++
-        w = Math.max(1, Math.floor(w / 2))
-        h = Math.max(1, Math.floor(h / 2))
-      }
-    }
+    const mipmapCount = generateMipmaps ? computeMipmapCount(width, height) : 1
 
     const cacheTempResources = this.#cacheTempResources
 
@@ -660,14 +670,19 @@ export class SparkGL {
       if (cacheTempResources && this.#cachedSrcTexture) {
         gl.deleteTexture(this.#cachedSrcTexture)
       }
+      // When caching, honor the minimum size and mipmap allocation hints.
+      const allocWidth = Math.max(width, this.#cacheMinSize)
+      const allocHeight = Math.max(height, this.#cacheMinSize)
+      const allocMipmaps = generateMipmaps || this.#cacheAllocateMipmaps
+      const allocMipLevelCount = allocMipmaps ? computeMipmapCount(allocWidth, allocHeight) : 1
       srcTexture = gl.createTexture()
       gl.bindTexture(gl.TEXTURE_2D, srcTexture)
-      gl.texStorage2D(gl.TEXTURE_2D, mipmapCount, gl.RGBA8, width, height)
+      gl.texStorage2D(gl.TEXTURE_2D, allocMipLevelCount, gl.RGBA8, allocWidth, allocHeight)
       if (cacheTempResources) {
         this.#cachedSrcTexture = srcTexture
-        this.#cachedSrcWidth = width
-        this.#cachedSrcHeight = height
-        this.#cachedSrcMipLevelCount = mipmapCount
+        this.#cachedSrcWidth = allocWidth
+        this.#cachedSrcHeight = allocHeight
+        this.#cachedSrcMipLevelCount = allocMipLevelCount
       }
     }
     gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST)
@@ -719,6 +734,12 @@ export class SparkGL {
     const dstBufferSize = blockSize * bw * bh
     let byteLength = dstBufferSize
 
+    // Minimum allocation size for cached block resources.
+    const minBlocks = Math.ceil(this.#cacheMinSize / 4)
+    const minBw = Math.max(bw, minBlocks)
+    const minBh = Math.max(bh, minBlocks)
+    const allocBufferSize = blockSize * minBw * minBh
+
     // Create or reuse temporary buffer.
     let dstBuffer
     if (cacheTempResources && this.#cachedBuffer && this.#cachedBufferSize >= dstBufferSize) {
@@ -728,18 +749,17 @@ export class SparkGL {
         gl.deleteBuffer(this.#cachedBuffer)
       }
       dstBuffer = gl.createBuffer()
+      gl.bindBuffer(gl.PIXEL_PACK_BUFFER, dstBuffer)
+      gl.bufferData(gl.PIXEL_PACK_BUFFER, cacheTempResources ? allocBufferSize : dstBufferSize, gl.STREAM_COPY)
       if (cacheTempResources) {
         this.#cachedBuffer = dstBuffer
-        this.#cachedBufferSize = dstBufferSize
+        this.#cachedBufferSize = allocBufferSize
       }
     }
     // We bind it to PIXEL_PACK_BUFFER to copy the render target into it.
     // We bind it to PIXEL_UNPACK_BUFFER to copy the contents to the compressed texture.
     gl.bindBuffer(gl.PIXEL_PACK_BUFFER, dstBuffer)
     gl.bindBuffer(gl.PIXEL_UNPACK_BUFFER, dstBuffer)
-
-    // @@ Can we skip this call?
-    gl.bufferData(gl.PIXEL_PACK_BUFFER, dstBufferSize, gl.STREAM_COPY)
 
     // Create or reuse render target (uint) texture.
     // Need different textures for 8-byte and 16-byte per block formats.
@@ -756,11 +776,11 @@ export class SparkGL {
         }
         mipDstTexture = gl.createTexture()
         gl.bindTexture(gl.TEXTURE_2D, mipDstTexture)
-        gl.texStorage2D(gl.TEXTURE_2D, 1, glUintFormat, bw, bh)
+        gl.texStorage2D(gl.TEXTURE_2D, 1, glUintFormat, minBw, minBh)
         if (cacheTempResources) {
           this.#cachedTexture8 = mipDstTexture
-          this.#cachedTexture8Width = bw
-          this.#cachedTexture8Height = bh
+          this.#cachedTexture8Width = minBw
+          this.#cachedTexture8Height = minBh
         }
       }
     } else {
@@ -774,11 +794,11 @@ export class SparkGL {
         }
         mipDstTexture = gl.createTexture()
         gl.bindTexture(gl.TEXTURE_2D, mipDstTexture)
-        gl.texStorage2D(gl.TEXTURE_2D, 1, glUintFormat, bw, bh)
+        gl.texStorage2D(gl.TEXTURE_2D, 1, glUintFormat, minBw, minBh)
         if (cacheTempResources) {
           this.#cachedTexture16 = mipDstTexture
-          this.#cachedTexture16Width = bw
-          this.#cachedTexture16Height = bh
+          this.#cachedTexture16Width = minBw
+          this.#cachedTexture16Height = minBh
         }
       }
     }

--- a/src/spark.js
+++ b/src/spark.js
@@ -1,5 +1,5 @@
 import shaders from "./shaders/wgsl-shaders.js"
-import { assert, loadImage, loadImageFromBlob, getSafariVersion, getFirefoxVersion } from "./utils.js"
+import { assert, loadImage, loadImageFromBlob, getSafariVersion, getFirefoxVersion, parseCacheTempResources } from "./utils.js"
 
 const SparkFormat = {
   ASTC_4x4_RGB: 0,
@@ -274,6 +274,8 @@ class Spark {
   #queryReadbackBuffer
 
   #cacheTempResources = false
+  #cacheMinSize = 0 // Minimum width/height cached resources are allocated for
+  #cacheAllocateMipmaps = false // Allocate a full mip chain for cached resources
   #cachedInputTexture = null
   #cachedTmpTexture = null
   #cachedOutputBuffer = null
@@ -286,7 +288,7 @@ class Spark {
    * @param {GPUDevice} device - WebGPU device.
    * @param {Object} options - Encoder options.
    * @param {boolean} options.preload - Whether to preload all encoder pipelines (false by default).
-   * @param {boolean} options.cacheTempResources - Whether to cache temporary resources for reuse across encodeTexture calls (false by default).
+   * @param {boolean|{minSize?: number, allocateMipmaps?: boolean}} options.cacheTempResources - Whether to cache temporary resources for reuse across encodeTexture calls (false by default). An object enables caching and hints how cached resources are allocated.
    * @param {boolean} options.verbose - Whether to enable verbose logging (false by default).
    * @returns {Promise<void>} Resolves when initialization is complete.
    */
@@ -668,9 +670,14 @@ class Spark {
         if (this.#cacheTempResources && this.#cachedInputTexture) {
           this.#cachedInputTexture.destroy()
         }
+        // When caching, honor the minimum size and mipmap allocation hints.
+        const allocWidth = Math.max(width, this.#cacheMinSize)
+        const allocHeight = Math.max(height, this.#cacheMinSize)
+        const allocMipmaps = mipmaps || this.#cacheAllocateMipmaps
+        const allocMipLevelCount = allocMipmaps ? computeMipmapLayout(allocWidth, allocHeight, blockSize, true).mipmapCount : 1
         inputTexture = this.#device.createTexture({
-          size: [width, height, 1],
-          mipLevelCount: mipmapCount,
+          size: [allocWidth, allocHeight, 1],
+          mipLevelCount: allocMipLevelCount,
           format: inputFormat,
           usage: inputUsage,
           ...(inputViewFormats ? { viewFormats: inputViewFormats } : {})
@@ -702,7 +709,7 @@ class Spark {
             this.#cachedTmpTexture.destroy()
           }
           tmpTexture = this.#device.createTexture({
-            size: [srcWidth, srcHeight, 1],
+            size: [Math.max(srcWidth, this.#cacheMinSize), Math.max(srcHeight, this.#cacheMinSize), 1],
             mipLevelCount: 1,
             format: inputFormat,
             // RENDER_ATTACHMENT usage is necessary for copyExternalImageToTexture
@@ -768,8 +775,15 @@ class Spark {
       if (this.#cacheTempResources && this.#cachedOutputBuffer) {
         this.#cachedOutputBuffer.destroy()
       }
+      // With a minimum cache size, allocate enough for that size (with a mip chain if hinted).
+      let allocSize = outputSize
+      if (this.#cacheMinSize > 0) {
+        const allocMipmaps = mipmaps || this.#cacheAllocateMipmaps
+        const minLayout = computeMipmapLayout(this.#cacheMinSize, this.#cacheMinSize, blockSize, allocMipmaps)
+        allocSize = Math.max(outputSize, minLayout.outputSize)
+      }
       outputBuffer = this.#device.createBuffer({
-        size: outputSize,
+        size: allocSize,
         usage: GPUBufferUsage.STORAGE | GPUBufferUsage.COPY_SRC
       })
       if (this.#cacheTempResources) {
@@ -935,7 +949,10 @@ class Spark {
 
     this.#device = device
     this.#verbose = verbose
-    this.#cacheTempResources = cacheTempResources
+    const cache = parseCacheTempResources(cacheTempResources)
+    this.#cacheTempResources = cache.enabled
+    this.#cacheMinSize = Math.min(cache.minSize, device.limits.maxTextureDimension2D)
+    this.#cacheAllocateMipmaps = cache.allocateMipmaps
     // Core devices expose the "core-features-and-limits" feature; compat devices don't.
     this.#compatibilityMode = !device.features.has("core-features-and-limits")
     // When supported, texture-compression-unaligned lifts the block alignment requirement.

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,23 @@
 // Shared utilities for spark.js and spark-gl.js
 
+/**
+ * Normalize the cacheTempResources option, which is either a boolean or an object
+ * { minSize, allocateMipmaps }. Returns { enabled, minSize, allocateMipmaps }.
+ * - minSize: minimum width/height (in texels) cached resources are allocated for; 0 means
+ *   "size of the encode that triggers the allocation".
+ * - allocateMipmaps: allocate a full mip chain even if the triggering encode has no mipmaps.
+ */
+export function parseCacheTempResources(option) {
+  if (typeof option === "object" && option !== null) {
+    const minSize = option.minSize ?? 0
+    if (!Number.isInteger(minSize) || minSize < 0) {
+      throw new Error(`cacheTempResources.minSize must be a non-negative integer, got ${minSize}`)
+    }
+    return { enabled: true, minSize, allocateMipmaps: Boolean(option.allocateMipmaps) }
+  }
+  return { enabled: Boolean(option), minSize: 0, allocateMipmaps: false }
+}
+
 export function assert(condition, message) {
   if (!condition) {
     throw new Error(message)

--- a/tests/browser/spark-gl-cache.test.js
+++ b/tests/browser/spark-gl-cache.test.js
@@ -126,3 +126,95 @@ test("SparkGL: cached source texture is reallocated for a larger image", async (
   await spark.dispose()
   assert.equal(tracker.live.size, 0, `leaked GL resources: ${tracker.describe()}`)
 })
+
+// Count createTexture calls: handle counting alone cannot see a delete+create reallocation.
+function countTextureCreations(gl) {
+  const counter = { count: 0 }
+  const raw = gl.createTexture
+  gl.createTexture = () => {
+    counter.count++
+    return raw.call(gl)
+  }
+  return counter
+}
+
+test("SparkGL: minSize allocates once for a sequence of growing encodes", async () => {
+  const tracker = createGL()
+  const gl = tracker.gl
+  const spark = SparkGL.create(gl, { cacheTempResources: { minSize: 512 } })
+  const format = spark.getSupportedFormats()[0]
+
+  const first = await spark.encodeTexture(await makeSolidImage(64, "#ff0000"), { format })
+  gl.deleteTexture(first.texture)
+
+  const created = countTextureCreations(gl)
+  for (const size of [128, 256, 512]) {
+    const result = await spark.encodeTexture(await makeSolidImage(size, "#00ff00"), { format })
+    assertSolid(readMipLevel(gl, result.texture, 0, size, size), [0, 255, 0], `${size} level 0`)
+    gl.deleteTexture(result.texture)
+  }
+  // readMipLevel creates one texture per call; plus one output per encode.
+  assert.equal(created.count, 6, `cache was reallocated: ${created.count} textures created`)
+
+  // Larger than minSize still grows the cache.
+  const big = await spark.encodeTexture(await makeSolidImage(1024, "#0000ff"), { format })
+  assertSolid(readMipLevel(gl, big.texture, 0, 1024, 1024), [0, 0, 255], "1024 level 0")
+  gl.deleteTexture(big.texture)
+
+  await spark.dispose()
+  assert.equal(tracker.live.size, 0, `leaked GL resources: ${tracker.describe()}`)
+})
+
+test("SparkGL: allocateMipmaps avoids reallocation when mipmaps are requested later", async () => {
+  const tracker = createGL()
+  const gl = tracker.gl
+  const spark = SparkGL.create(gl, { cacheTempResources: { minSize: 64, allocateMipmaps: true } })
+  const format = spark.getSupportedFormats()[0]
+
+  const flat = await spark.encodeTexture(await makeSolidImage(64, "#ff0000"), { format })
+  gl.deleteTexture(flat.texture)
+
+  const created = countTextureCreations(gl)
+  const mipped = await spark.encodeTexture(await makeSolidImage(32, "#00ff00"), { format, generateMipmaps: true })
+  assert.equal(created.count, 1, "expected only the output texture to be created")
+  assertSolid(readMipLevel(gl, mipped.texture, 2, 8, 8), [0, 255, 0], "green level 2")
+  gl.deleteTexture(mipped.texture)
+
+  await spark.dispose()
+  assert.equal(tracker.live.size, 0, `leaked GL resources: ${tracker.describe()}`)
+})
+
+test("SparkGL: without allocateMipmaps the source texture is reallocated once for mipmaps", async () => {
+  const tracker = createGL()
+  const gl = tracker.gl
+  const spark = SparkGL.create(gl, { cacheTempResources: { minSize: 64 } })
+  const format = spark.getSupportedFormats()[0]
+
+  const flat = await spark.encodeTexture(await makeSolidImage(64, "#ff0000"), { format })
+  gl.deleteTexture(flat.texture)
+
+  const created = countTextureCreations(gl)
+  const mipped = await spark.encodeTexture(await makeSolidImage(32, "#00ff00"), { format, generateMipmaps: true })
+  assert.equal(created.count, 2, "expected output texture plus one source reallocation")
+  gl.deleteTexture(mipped.texture)
+
+  // The reallocated chain is sized for minSize, so a mipmapped 64x64 reuses it.
+  const again = await spark.encodeTexture(await makeSolidImage(64, "#0000ff"), { format, generateMipmaps: true })
+  assert.equal(created.count, 3, "expected no further reallocation")
+  assertSolid(readMipLevel(gl, again.texture, 3, 8, 8), [0, 0, 255], "blue level 3")
+  gl.deleteTexture(again.texture)
+
+  await spark.dispose()
+  assert.equal(tracker.live.size, 0, `leaked GL resources: ${tracker.describe()}`)
+})
+
+test("SparkGL: invalid minSize is rejected", async () => {
+  const tracker = createGL()
+  let threw = false
+  try {
+    SparkGL.create(tracker.gl, { cacheTempResources: { minSize: -1 } })
+  } catch {
+    threw = true
+  }
+  assert.ok(threw, "expected an error for negative minSize")
+})

--- a/tests/browser/spark.test.js
+++ b/tests/browser/spark.test.js
@@ -51,3 +51,60 @@ test("Spark: dispose with timestamp queries enabled", async () => {
   })
   device.destroy()
 })
+
+// Count texture/buffer allocations made through the device.
+function countAllocations(device) {
+  const counts = { textures: 0, buffers: 0 }
+  const createTexture = device.createTexture.bind(device)
+  const createBuffer = device.createBuffer.bind(device)
+  device.createTexture = desc => {
+    counts.textures++
+    return createTexture(desc)
+  }
+  device.createBuffer = desc => {
+    counts.buffers++
+    return createBuffer(desc)
+  }
+  return counts
+}
+
+test("Spark: minSize allocates once for a sequence of growing encodes", async () => {
+  const device = await createDevice()
+  const spark = await Spark.create(device, { cacheTempResources: { minSize: 512 } })
+  const format = spark.getSupportedFormats()[0]
+
+  await expectNoValidationErrors(device, async () => {
+    const first = await spark.encodeTexture(await makeTestImage(64, 64), { format })
+    first.destroy()
+
+    const counts = countAllocations(device)
+    for (const size of [128, 256, 512]) {
+      const result = await spark.encodeTexture(await makeTestImage(size, size), { format })
+      result.destroy()
+    }
+    // One output texture per encode, no cache reallocations.
+    assert.equal(counts.textures, 3, `unexpected texture allocations: ${counts.textures}`)
+    assert.equal(counts.buffers, 0, `unexpected buffer allocations: ${counts.buffers}`)
+    spark.dispose()
+  })
+  device.destroy()
+})
+
+test("Spark: allocateMipmaps avoids reallocation when mipmaps are requested later", async () => {
+  const device = await createDevice()
+  const spark = await Spark.create(device, { cacheTempResources: { minSize: 64, allocateMipmaps: true } })
+  const format = spark.getSupportedFormats()[0]
+
+  await expectNoValidationErrors(device, async () => {
+    const flat = await spark.encodeTexture(await makeTestImage(64, 64), { format })
+    flat.destroy()
+
+    const counts = countAllocations(device)
+    const mipped = await spark.encodeTexture(await makeTestImage(32, 32), { format, generateMipmaps: true })
+    mipped.destroy()
+    assert.equal(counts.textures, 1, `unexpected texture allocations: ${counts.textures}`)
+    assert.equal(counts.buffers, 0, `unexpected buffer allocations: ${counts.buffers}`)
+    spark.dispose()
+  })
+  device.destroy()
+})


### PR DESCRIPTION
Previously a sequence of encodes of increasing size (for example 64, 128, 256, 512) would reallocate at every step. To avoid this, this PR allows you to set `cacheTempResources` to an object instead of `true` to control how the cached resources are allocated. Both fields are optional and behave the same in `Spark` and `SparkGL`:

- `minSize` (`number`, default: `0`) - Minimum width and height, in texels, that cached resources are allocated for.
- `allocateMipmaps` (`boolean`, default: `false`) - Allocate cached resources with a full mip chain even if the encode that triggers the allocation does not generate mipmaps. 

Additionally, in `SparkGL` we don't call `gl.bufferData` to size the pixel buffer object on every encode anymore, but only when the buffer is created. The unintended consequence of the redundant calls was that the buffer was orphaned and a new one created. This is not the case anymore.

This addresses the 5th point of https://github.com/Ludicon/spark.js/pull/46