### PR TITLE
Fix concurrent encode bug.

### DIFF
--- a/src/spark.js
+++ b/src/spark.js
@@ -584,8 +584,10 @@ class Spark {
 
     const format = await this.#getBestMatchingFormat(options, image)
 
-    // Start loading the pipeline as soon as we know the format.
-    const pipelinePromise = this.#loadPipeline(format)
+    // Load the pipeline and wait for it before touching any cached resource: everything from here to
+    // queue.submit() must run without suspending, otherwise a concurrent encodeTexture()
+    // call could overwrite or reallocate the cached textures and buffers underneath us.
+    const pipeline = await this.#loadPipeline(format)
 
     // Round up the size to meet WebGPU's 4-texel alignment requirement, unless the texture-compression-unaligned feature lifts it.
     const width = this.#supportsUnalignedTextures ? srcWidth : Math.ceil(srcWidth / 4) * 4
@@ -807,9 +809,6 @@ class Spark {
         }
       }
     }
-
-    // Make sure the pipeline is loaded. Wait if necessary.
-    const pipeline = await pipelinePromise
 
     const pass = commandEncoder.beginComputePass(args)
     pass.setPipeline(pipeline)

--- a/tests/browser/spark-gl-cache.test.js
+++ b/tests/browser/spark-gl-cache.test.js
@@ -1,5 +1,5 @@
 import { SparkGL } from "../../src/index.js"
-import { test, assert, skip, isSoftwareGL } from "../harness.js"
+import { test, assert, skip, isSoftwareGL, makeSolidImage } from "../harness.js"
 import { trackGL } from "../gl-tracker.js"
 
 function createGL() {
@@ -7,14 +7,6 @@ function createGL() {
   if (!gl) skip("WebGL2 not available")
   if (isSoftwareGL(gl)) skip("compressed mip levels are not reliable on software GL")
   return trackGL(gl)
-}
-
-async function makeSolidImage(size, color) {
-  const canvas = new OffscreenCanvas(size, size)
-  const ctx = canvas.getContext("2d")
-  ctx.fillStyle = color
-  ctx.fillRect(0, 0, size, size)
-  return createImageBitmap(canvas)
 }
 
 // Decode one mip level of a compressed texture back to RGBA8 by rendering it with texelFetch.
@@ -65,6 +57,7 @@ function readMipLevel(gl, texture, level, width, height) {
 
   gl.deleteFramebuffer(fbo)
   gl.deleteTexture(target)
+  gl.useProgram(null)
   gl.deleteProgram(program)
   gl.deleteShader(vsShader)
   gl.deleteShader(fsShader)
@@ -84,7 +77,7 @@ test("SparkGL: cached source texture is reused correctly for a smaller image wit
   const tracker = createGL()
   const gl = tracker.gl
   const spark = SparkGL.create(gl, { cacheTempResources: true })
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
 
   // First encode sizes the cache at 32x32 with 4 mip levels and leaves the source texture dirty.
   const red = await spark.encodeTexture(await makeSolidImage(32, "#ff0000"), { format, generateMipmaps: true })
@@ -110,7 +103,7 @@ test("SparkGL: cached source texture is reallocated for a larger image", async (
   const tracker = createGL()
   const gl = tracker.gl
   const spark = SparkGL.create(gl, { cacheTempResources: true })
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
 
   const small = await spark.encodeTexture(await makeSolidImage(16, "#ff0000"), { format })
   gl.deleteTexture(small.texture)
@@ -142,7 +135,7 @@ test("SparkGL: minSize allocates once for a sequence of growing encodes", async 
   const tracker = createGL()
   const gl = tracker.gl
   const spark = SparkGL.create(gl, { cacheTempResources: { minSize: 512 } })
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
 
   const first = await spark.encodeTexture(await makeSolidImage(64, "#ff0000"), { format })
   gl.deleteTexture(first.texture)
@@ -169,7 +162,7 @@ test("SparkGL: allocateMipmaps avoids reallocation when mipmaps are requested la
   const tracker = createGL()
   const gl = tracker.gl
   const spark = SparkGL.create(gl, { cacheTempResources: { minSize: 64, allocateMipmaps: true } })
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
 
   const flat = await spark.encodeTexture(await makeSolidImage(64, "#ff0000"), { format })
   gl.deleteTexture(flat.texture)
@@ -188,7 +181,7 @@ test("SparkGL: without allocateMipmaps the source texture is reallocated once fo
   const tracker = createGL()
   const gl = tracker.gl
   const spark = SparkGL.create(gl, { cacheTempResources: { minSize: 64 } })
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
 
   const flat = await spark.encodeTexture(await makeSolidImage(64, "#ff0000"), { format })
   gl.deleteTexture(flat.texture)

--- a/tests/browser/spark-gl.test.js
+++ b/tests/browser/spark-gl.test.js
@@ -38,7 +38,7 @@ test("SparkGL: dispose before any encode does not leak", async () => {
 test("SparkGL: dispose while a program is compiling rejects the encode cleanly", async () => {
   const tracker = createGL()
   const spark = SparkGL.create(tracker.gl)
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
 
   const image = await makeTestImage()
   const pending = spark.encodeTexture(image, { format })
@@ -52,7 +52,7 @@ test("SparkGL: dispose can be called twice", async () => {
   const tracker = createGL()
   const spark = SparkGL.create(tracker.gl, { cacheTempResources: true })
   const image = await makeTestImage()
-  const result = await spark.encodeTexture(image, { format: spark.getSupportedFormats()[0] })
+  const result = await spark.encodeTexture(image, { format: "rgb" })
   tracker.gl.deleteTexture(result.texture)
 
   await spark.dispose()
@@ -65,7 +65,7 @@ test("SparkGL: encode without cacheTempResources leaves only the output texture"
   const spark = SparkGL.create(tracker.gl)
   const image = await makeTestImage()
   const before = tracker.live.size
-  const result = await spark.encodeTexture(image, { format: spark.getSupportedFormats()[0], generateMipmaps: true })
+  const result = await spark.encodeTexture(image, { format: "rgb", generateMipmaps: true })
   const after = tracker.live.size
   // Program + vertex shader are cached; the output texture belongs to the caller.
   const owned = [...tracker.live.entries()].filter(([, kind]) => kind === "Texture")
@@ -80,7 +80,7 @@ test("SparkGL: encode without cacheTempResources leaves only the output texture"
 test("SparkGL: repeated encodes with cacheTempResources do not grow resource count", async () => {
   const tracker = createGL()
   const spark = SparkGL.create(tracker.gl, { cacheTempResources: true })
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
   const image = await makeTestImage()
 
   const encode = async () => {

--- a/tests/browser/spark.test.js
+++ b/tests/browser/spark.test.js
@@ -1,5 +1,5 @@
 import { Spark } from "../../src/index.js"
-import { test, assert, skip, makeTestImage } from "../harness.js"
+import { test, assert, skip, makeTestImage, makeSolidImage } from "../harness.js"
 
 async function createDevice() {
   const adapter = await navigator.gpu?.requestAdapter()
@@ -71,7 +71,7 @@ function countAllocations(device) {
 test("Spark: minSize allocates once for a sequence of growing encodes", async () => {
   const device = await createDevice()
   const spark = await Spark.create(device, { cacheTempResources: { minSize: 512 } })
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
 
   await expectNoValidationErrors(device, async () => {
     const first = await spark.encodeTexture(await makeTestImage(64, 64), { format })
@@ -93,7 +93,7 @@ test("Spark: minSize allocates once for a sequence of growing encodes", async ()
 test("Spark: allocateMipmaps avoids reallocation when mipmaps are requested later", async () => {
   const device = await createDevice()
   const spark = await Spark.create(device, { cacheTempResources: { minSize: 64, allocateMipmaps: true } })
-  const format = spark.getSupportedFormats()[0]
+  const format = "rgb"
 
   await expectNoValidationErrors(device, async () => {
     const flat = await spark.encodeTexture(await makeTestImage(64, 64), { format })
@@ -104,6 +104,89 @@ test("Spark: allocateMipmaps avoids reallocation when mipmaps are requested late
     mipped.destroy()
     assert.equal(counts.textures, 1, `unexpected texture allocations: ${counts.textures}`)
     assert.equal(counts.buffers, 0, `unexpected buffer allocations: ${counts.buffers}`)
+    spark.dispose()
+  })
+  device.destroy()
+})
+
+// Decode mip level 0 of a compressed texture to RGBA8 by sampling it in a render pass.
+async function readTexture(device, texture, width, height) {
+  const module = device.createShaderModule({
+    code: `
+      @vertex fn vs(@builtin(vertex_index) i: u32) -> @builtin(position) vec4f {
+        let p = vec2f(f32((i << 1u) & 2u), f32(i & 2u));
+        return vec4f(p * 2.0 - 1.0, 0.0, 1.0);
+      }
+      @group(0) @binding(0) var t: texture_2d<f32>;
+      @fragment fn fs(@builtin(position) pos: vec4f) -> @location(0) vec4f {
+        return textureLoad(t, vec2i(pos.xy), 0);
+      }`
+  })
+  const pipeline = await device.createRenderPipelineAsync({
+    layout: "auto",
+    vertex: { module, entryPoint: "vs" },
+    fragment: { module, entryPoint: "fs", targets: [{ format: "rgba8unorm" }] }
+  })
+  const target = device.createTexture({
+    size: [width, height],
+    format: "rgba8unorm",
+    usage: GPUTextureUsage.RENDER_ATTACHMENT | GPUTextureUsage.COPY_SRC
+  })
+  const bytesPerRow = Math.ceil((width * 4) / 256) * 256
+  const buffer = device.createBuffer({ size: bytesPerRow * height, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.MAP_READ })
+  const bindGroup = device.createBindGroup({
+    layout: pipeline.getBindGroupLayout(0),
+    entries: [{ binding: 0, resource: texture.createView({ baseMipLevel: 0, mipLevelCount: 1 }) }]
+  })
+
+  const encoder = device.createCommandEncoder()
+  const pass = encoder.beginRenderPass({
+    colorAttachments: [{ view: target.createView(), loadOp: "clear", storeOp: "store" }]
+  })
+  pass.setPipeline(pipeline)
+  pass.setBindGroup(0, bindGroup)
+  pass.draw(3)
+  pass.end()
+  encoder.copyTextureToBuffer({ texture: target }, { buffer, bytesPerRow }, [width, height])
+  device.queue.submit([encoder.finish()])
+
+  await buffer.mapAsync(GPUMapMode.READ)
+  const mapped = new Uint8Array(buffer.getMappedRange())
+  const pixels = new Uint8Array(width * height * 4)
+  for (let y = 0; y < height; y++) {
+    pixels.set(mapped.subarray(y * bytesPerRow, y * bytesPerRow + width * 4), y * width * 4)
+  }
+  buffer.unmap()
+  buffer.destroy()
+  target.destroy()
+  return pixels
+}
+
+function assertSolid(pixels, [r, g, b], label, tolerance = 8) {
+  for (let i = 0; i < pixels.length; i += 4) {
+    const ok = Math.abs(pixels[i] - r) <= tolerance && Math.abs(pixels[i + 1] - g) <= tolerance && Math.abs(pixels[i + 2] - b) <= tolerance
+    if (!ok) {
+      throw new Error(`${label}: pixel ${i / 4} is (${pixels[i]}, ${pixels[i + 1]}, ${pixels[i + 2]}), expected (${r}, ${g}, ${b})`)
+    }
+  }
+}
+
+test("Spark: concurrent encodes with cacheTempResources do not interfere", async () => {
+  const device = await createDevice()
+  // No preload: the first encode waits for the pipeline to compile, which is when a
+  // concurrent encode can reuse or reallocate the cached resources underneath it.
+  const spark = await Spark.create(device, { cacheTempResources: true })
+  const format = "rgb"
+
+  await expectNoValidationErrors(device, async () => {
+    const [red, green] = await Promise.all([
+      spark.encodeTexture(await makeSolidImage(64, "#ff0000"), { format }),
+      spark.encodeTexture(await makeSolidImage(128, "#00ff00"), { format })
+    ])
+    assertSolid(await readTexture(device, red, 64, 64), [255, 0, 0], "red")
+    assertSolid(await readTexture(device, green, 128, 128), [0, 255, 0], "green")
+    red.destroy()
+    green.destroy()
     spark.dispose()
   })
   device.destroy()

--- a/tests/harness.html
+++ b/tests/harness.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <title>spark.js tests</title>
+    <link rel="icon" href="data:," />
   </head>
   <body>
     <pre id="output"></pre>

--- a/tests/harness.js
+++ b/tests/harness.js
@@ -87,3 +87,12 @@ export async function makeTestImage(width = 16, height = 16) {
   ctx.fillRect(0, 0, width, height)
   return createImageBitmap(canvas)
 }
+
+/** A solid-colour ImageBitmap, e.g. makeSolidImage(64, "#ff0000"). */
+export async function makeSolidImage(size, color) {
+  const canvas = new OffscreenCanvas(size, size)
+  const ctx = canvas.getContext("2d")
+  ctx.fillStyle = color
+  ctx.fillRect(0, 0, size, size)
+  return createImageBitmap(canvas)
+}


### PR DESCRIPTION
Move async early to avoid concurrent access to shared state. Added test to reproduce the bug; doesn't trigger anymore after the fix.

With this change `Spark` matches the behavior of the `SparkGL` backend. The unfortunate side effect is that it's not possible to overlap program compilation with the first texture upload, and instead we wait for the program compilation.

In larger applications there's probably enough work to do between the initialization and the first texture load so in practice it should not make much of a difference.