### PR TITLE
Fix edge bleeding when caching enabled.

### DIFF
--- a/API.md
+++ b/API.md
@@ -324,11 +324,11 @@ const textures = await Promise.all(
 spark.freeTempResources()
 ```
 
-Cached resources are allocated lazily, the first time an encode needs them, and are sized by that encode. A later encode that is larger, or that needs more mipmap levels, reallocates them; a smaller one reuses them. They are released by `freeTempResources()` or `dispose()`.
+Cached resources are allocated lazily, the first time an encode needs them, and are sized by that encode. The block-level resources (render targets and buffers) are reused by any encode that fits in them and reallocated by a larger one. The source texture is only reused by images of exactly the same size: the mipmap generator and the encoders read the whole texture, so a larger one would bleed the previous image into the edges and mipmaps of the new one. All cached resources are released by `freeTempResources()` or `dispose()`.
 
 #### Sizing the cache
 
-Because the cache only grows on demand, a sequence of encodes of increasing size (for example 64, 128, 256, 512) reallocates at every step. To avoid this, pass an object instead of `true` to control how the cached resources are allocated. Both fields are optional and behave the same in `Spark` and `SparkGL`:
+Because the cache only grows on demand, a sequence of encodes of increasing size (for example 64, 128, 256, 512) reallocates the block-level resources at every step. To avoid this, pass an object instead of `true` to control how the cached resources are allocated. Both fields are optional and behave the same in `Spark` and `SparkGL`:
 
 ```js
 const spark = await Spark.create(device, {
@@ -336,10 +336,10 @@ const spark = await Spark.create(device, {
 })
 ```
 
-- `minSize` (`number`, default: `0`) - Minimum width and height, in texels, that cached resources are allocated for. With `minSize: 512` the sequence above allocates once, on the first encode. Encodes larger than `minSize` still grow the cache. The value is clamped to the device's maximum texture size.
-- `allocateMipmaps` (`boolean`, default: `false`) - Allocate cached resources with a full mip chain even if the encode that triggers the allocation does not generate mipmaps. By default the chain is only allocated when the triggering encode requests mipmaps, so callers that never use mipmaps (for example tile renderers) don't pay for it. Callers that mix mipmapped and non-mipmapped encodes can set this to avoid a reallocation the first time mipmaps are requested.
+- `minSize` (`number`, default: `0`) - Minimum width and height, in texels, that the block-level resources are allocated for. With `minSize: 512` the sequence above allocates them once, on the first encode. Encodes larger than `minSize` still grow the cache. The value is clamped to the device's maximum texture size. It does not apply to the source texture, for the reason given above.
+- `allocateMipmaps` (`boolean`, default: `false`) - Allocate the cached source texture with a full mip chain even if the encode that triggers the allocation does not generate mipmaps. By default the chain is only allocated when the triggering encode requests mipmaps, so callers that never use mipmaps (for example tile renderers) don't pay for it. Callers that mix mipmapped and non-mipmapped encodes of the same size can set this to avoid a reallocation the first time mipmaps are requested.
 
-Memory cost for `minSize = N` is roughly `N² × 4` bytes for the RGBA8 source copy (×4/3 with mipmaps), plus `(N/4)² × 16` bytes per block render target or output buffer. For `N = 4096` that is 64–85 MB plus 16 MB.
+Memory cost for `minSize = N` is roughly `(N/4)² × 16` bytes per block render target or output buffer, i.e. 16 MB for `N = 4096`. The source texture costs `width × height × 4` bytes (×4/3 with mipmaps) for the last encoded size.
 
 ### Verbose Logging
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,17 +10,19 @@
  */
 export interface SparkCacheOptions {
   /**
-   * Minimum width and height (in texels) that cached resources are allocated for, so that a
-   * sequence of encodes of increasing size up to this value does not reallocate them.
-   * Encodes larger than this still grow the cache. Clamped to the device's maximum texture size.
+   * Minimum width and height (in texels) that the cached block-level resources (render
+   * targets and buffers) are allocated for, so that a sequence of encodes of increasing size
+   * up to this value does not reallocate them. Encodes larger than this still grow the cache.
+   * Does not apply to the cached source texture, which is only reused for images of exactly
+   * the same size. Clamped to the device's maximum texture size.
    * @default 0 (size of the encode that triggers the allocation)
    */
   minSize?: number
 
   /**
-   * Allocate cached resources with a full mip chain even when the encode that triggers the
-   * allocation does not generate mipmaps. Avoids a reallocation the first time a mipmapped
-   * encode is requested, at the cost of ~33% more memory for the source texture.
+   * Allocate the cached source texture with a full mip chain even when the encode that
+   * triggers the allocation does not generate mipmaps. Avoids a reallocation the first time a
+   * mipmapped encode of the same size is requested, at the cost of ~33% more memory.
    * @default false
    */
   allocateMipmaps?: boolean

--- a/src/spark-gl.js
+++ b/src/spark-gl.js
@@ -652,15 +652,16 @@ export class SparkGL {
 
     const cacheTempResources = this.#cacheTempResources
 
-    // Create or reuse input texture. A cached texture is reused when it is at least as large
-    // as the image and has at least as many mip levels; the encoder only reads the region
-    // covered by the image, so a larger texture is fine.
+    // Create or reuse input texture. A cached texture is only reused when it has exactly the
+    // same size as the image: generateMipmap and the encoders read the whole texture (edge
+    // blocks and mip filters fetch past the image extent), so a larger texture would bleed
+    // the previous image into the result. See https://github.com/Ludicon/spark.js/issues/42.
     let srcTexture
     const needsSrcRealloc =
       !cacheTempResources ||
       !this.#cachedSrcTexture ||
-      this.#cachedSrcWidth < width ||
-      this.#cachedSrcHeight < height ||
+      this.#cachedSrcWidth !== width ||
+      this.#cachedSrcHeight !== height ||
       this.#cachedSrcMipLevelCount < mipmapCount
 
     if (!needsSrcRealloc) {
@@ -670,18 +671,16 @@ export class SparkGL {
       if (cacheTempResources && this.#cachedSrcTexture) {
         gl.deleteTexture(this.#cachedSrcTexture)
       }
-      // When caching, honor the minimum size and mipmap allocation hints.
-      const allocWidth = Math.max(width, this.#cacheMinSize)
-      const allocHeight = Math.max(height, this.#cacheMinSize)
+      // When caching, honor the mipmap allocation hint (minSize does not apply, see above).
       const allocMipmaps = generateMipmaps || this.#cacheAllocateMipmaps
-      const allocMipLevelCount = allocMipmaps ? computeMipmapCount(allocWidth, allocHeight) : 1
+      const allocMipLevelCount = allocMipmaps ? computeMipmapCount(width, height) : 1
       srcTexture = gl.createTexture()
       gl.bindTexture(gl.TEXTURE_2D, srcTexture)
-      gl.texStorage2D(gl.TEXTURE_2D, allocMipLevelCount, gl.RGBA8, allocWidth, allocHeight)
+      gl.texStorage2D(gl.TEXTURE_2D, allocMipLevelCount, gl.RGBA8, width, height)
       if (cacheTempResources) {
         this.#cachedSrcTexture = srcTexture
-        this.#cachedSrcWidth = allocWidth
-        this.#cachedSrcHeight = allocHeight
+        this.#cachedSrcWidth = width
+        this.#cachedSrcHeight = height
         this.#cachedSrcMipLevelCount = allocMipLevelCount
       }
     }

--- a/src/spark.js
+++ b/src/spark.js
@@ -664,12 +664,15 @@ class Spark {
     let inputTexture
 
     if (needsProcessing || !(image instanceof GPUTexture && !mipmaps)) {
-      // Create or reuse input texture
+      // Create or reuse input texture. A cached texture is only reused when it has exactly the
+      // same size as the image: the mipmap and encoder shaders size themselves from the texture
+      // (edge blocks and mip filters fetch past the image extent), so a larger texture would
+      // bleed the previous image into the result. See https://github.com/Ludicon/spark.js/issues/42.
       const needsRealloc =
         !this.#cacheTempResources ||
         !this.#cachedInputTexture ||
-        this.#cachedInputTexture.width < width ||
-        this.#cachedInputTexture.height < height ||
+        this.#cachedInputTexture.width !== width ||
+        this.#cachedInputTexture.height !== height ||
         this.#cachedInputTexture.format != inputFormat ||
         this.#cachedInputTexture.mipLevelCount < mipmapCount
 
@@ -679,13 +682,11 @@ class Spark {
         if (this.#cacheTempResources && this.#cachedInputTexture) {
           this.#cachedInputTexture.destroy()
         }
-        // When caching, honor the minimum size and mipmap allocation hints.
-        const allocWidth = Math.max(width, this.#cacheMinSize)
-        const allocHeight = Math.max(height, this.#cacheMinSize)
+        // When caching, honor the mipmap allocation hint (minSize does not apply, see above).
         const allocMipmaps = mipmaps || this.#cacheAllocateMipmaps
-        const allocMipLevelCount = allocMipmaps ? computeMipmapLayout(allocWidth, allocHeight, blockSize, true).mipmapCount : 1
+        const allocMipLevelCount = allocMipmaps ? computeMipmapLayout(width, height, blockSize, true).mipmapCount : 1
         inputTexture = this.#device.createTexture({
-          size: [allocWidth, allocHeight, 1],
+          size: [width, height, 1],
           mipLevelCount: allocMipLevelCount,
           format: inputFormat,
           usage: inputUsage,
@@ -703,13 +704,14 @@ class Spark {
       if (image instanceof GPUTexture) {
         this.#processInputTexture(commandEncoder, image, inputTexture, width, height, srgb, options.flipY)
       } else {
-        // Create or reuse temporary texture using the input size
+        // Create or reuse temporary texture using the input size. Exact size only: the resize
+        // and flip shaders sample it with normalized coordinates over the whole texture.
         const needsTmpRealloc =
           !this.#cacheTempResources ||
           !this.#cachedTmpTexture ||
-          this.#cachedTmpTexture.width < srcWidth ||
-          this.#cachedTmpTexture.height < srcHeight ||
-          this.#cachedInputTexture.format != inputFormat
+          this.#cachedTmpTexture.width !== srcWidth ||
+          this.#cachedTmpTexture.height !== srcHeight ||
+          this.#cachedTmpTexture.format != inputFormat
 
         if (this.#cacheTempResources && this.#cachedTmpTexture && !needsTmpRealloc) {
           tmpTexture = this.#cachedTmpTexture
@@ -718,7 +720,7 @@ class Spark {
             this.#cachedTmpTexture.destroy()
           }
           tmpTexture = this.#device.createTexture({
-            size: [Math.max(srcWidth, this.#cacheMinSize), Math.max(srcHeight, this.#cacheMinSize), 1],
+            size: [srcWidth, srcHeight, 1],
             mipLevelCount: 1,
             format: inputFormat,
             // RENDER_ATTACHMENT usage is necessary for copyExternalImageToTexture

--- a/tests/browser/spark-gl-cache.test.js
+++ b/tests/browser/spark-gl-cache.test.js
@@ -1,5 +1,5 @@
 import { SparkGL } from "../../src/index.js"
-import { test, assert, skip, isSoftwareGL, makeSolidImage } from "../harness.js"
+import { test, assert, skip, isSoftwareGL, makeSolidImage, makeNoiseImage, firstDifference } from "../harness.js"
 import { trackGL } from "../gl-tracker.js"
 
 function createGL() {
@@ -73,26 +73,60 @@ function assertSolid(pixels, [r, g, b], label, tolerance = 8) {
   }
 }
 
-test("SparkGL: cached source texture is reused correctly for a smaller image with mipmaps", async () => {
+// Count createTexture calls: handle counting alone cannot see a delete+create reallocation.
+function countTextureCreations(gl) {
+  const counter = { count: 0 }
+  const raw = gl.createTexture
+  gl.createTexture = () => {
+    counter.count++
+    return raw.call(gl)
+  }
+  return counter
+}
+
+test("SparkGL: cached source texture is reused for an image of the same size", async () => {
   const tracker = createGL()
   const gl = tracker.gl
   const spark = SparkGL.create(gl, { cacheTempResources: true })
   const format = "rgb"
 
-  // First encode sizes the cache at 32x32 with 4 mip levels and leaves the source texture dirty.
+  // First encode sizes the cache and leaves the source texture's base level dirty.
   const red = await spark.encodeTexture(await makeSolidImage(32, "#ff0000"), { format, generateMipmaps: true })
   assertSolid(readMipLevel(gl, red.texture, 0, 32, 32), [255, 0, 0], "red level 0")
   gl.deleteTexture(red.texture)
 
-  const live = tracker.live.size
+  const created = countTextureCreations(gl)
+  const green = await spark.encodeTexture(await makeSolidImage(32, "#00ff00"), { format, generateMipmaps: true })
+  assert.equal(created.count, 1, "expected only the output texture to be created")
+  assert.equal(green.mipmapCount, 4, "unexpected mipmap count")
+  for (let level = 0; level < 4; level++) {
+    const size = 32 >> level
+    assertSolid(readMipLevel(gl, green.texture, level, size, size), [0, 255, 0], `green level ${level}`)
+  }
+  gl.deleteTexture(green.texture)
 
-  // Second encode must reuse the larger cached source texture: only the new output is added.
+  await spark.dispose()
+  assert.equal(tracker.live.size, 0, `leaked GL resources: ${tracker.describe()}`)
+})
+
+test("SparkGL: cached source texture is reallocated for a smaller image", async () => {
+  const tracker = createGL()
+  const gl = tracker.gl
+  const spark = SparkGL.create(gl, { cacheTempResources: true })
+  const format = "rgb"
+
+  const red = await spark.encodeTexture(await makeSolidImage(32, "#ff0000"), { format, generateMipmaps: true })
+  gl.deleteTexture(red.texture)
+
+  // A larger cached texture must not be reused: its stale content would bleed into edge
+  // blocks and mipmaps (https://github.com/Ludicon/spark.js/issues/42).
+  const created = countTextureCreations(gl)
   const green = await spark.encodeTexture(await makeSolidImage(16, "#00ff00"), { format, generateMipmaps: true })
-  assert.equal(tracker.live.size, live + 1, `source texture was reallocated: ${tracker.describe()}`)
-  assert.equal(green.mipmapCount, 3, "unexpected mipmap count")
-  assertSolid(readMipLevel(gl, green.texture, 0, 16, 16), [0, 255, 0], "green level 0")
-  assertSolid(readMipLevel(gl, green.texture, 1, 8, 8), [0, 255, 0], "green level 1")
-  assertSolid(readMipLevel(gl, green.texture, 2, 4, 4), [0, 255, 0], "green level 2")
+  assert.equal(created.count, 2, "expected the output texture and a reallocated source texture")
+  for (let level = 0; level < 3; level++) {
+    const size = 16 >> level
+    assertSolid(readMipLevel(gl, green.texture, level, size, size), [0, 255, 0], `green level ${level}`)
+  }
   gl.deleteTexture(green.texture)
 
   await spark.dispose()
@@ -120,17 +154,6 @@ test("SparkGL: cached source texture is reallocated for a larger image", async (
   assert.equal(tracker.live.size, 0, `leaked GL resources: ${tracker.describe()}`)
 })
 
-// Count createTexture calls: handle counting alone cannot see a delete+create reallocation.
-function countTextureCreations(gl) {
-  const counter = { count: 0 }
-  const raw = gl.createTexture
-  gl.createTexture = () => {
-    counter.count++
-    return raw.call(gl)
-  }
-  return counter
-}
-
 test("SparkGL: minSize allocates once for a sequence of growing encodes", async () => {
   const tracker = createGL()
   const gl = tracker.gl
@@ -141,13 +164,22 @@ test("SparkGL: minSize allocates once for a sequence of growing encodes", async 
   gl.deleteTexture(first.texture)
 
   const created = countTextureCreations(gl)
+  let buffersCreated = 0
+  const rawCreateBuffer = gl.createBuffer
+  gl.createBuffer = () => {
+    buffersCreated++
+    return rawCreateBuffer.call(gl)
+  }
   for (const size of [128, 256, 512]) {
     const result = await spark.encodeTexture(await makeSolidImage(size, "#00ff00"), { format })
     assertSolid(readMipLevel(gl, result.texture, 0, size, size), [0, 255, 0], `${size} level 0`)
     gl.deleteTexture(result.texture)
   }
-  // readMipLevel creates one texture per call; plus one output per encode.
-  assert.equal(created.count, 6, `cache was reallocated: ${created.count} textures created`)
+  // Per encode: the output texture, the source texture (exact size, so reallocated for each
+  // new size) and one texture from readMipLevel. The block render target must not be
+  // reallocated, nor the readback buffer.
+  assert.equal(created.count, 9, `block render target was reallocated: ${created.count} textures created`)
+  assert.equal(buffersCreated, 0, `readback buffer was reallocated: ${buffersCreated} buffers created`)
 
   // Larger than minSize still grows the cache.
   const big = await spark.encodeTexture(await makeSolidImage(1024, "#0000ff"), { format })
@@ -168,9 +200,9 @@ test("SparkGL: allocateMipmaps avoids reallocation when mipmaps are requested la
   gl.deleteTexture(flat.texture)
 
   const created = countTextureCreations(gl)
-  const mipped = await spark.encodeTexture(await makeSolidImage(32, "#00ff00"), { format, generateMipmaps: true })
+  const mipped = await spark.encodeTexture(await makeSolidImage(64, "#00ff00"), { format, generateMipmaps: true })
   assert.equal(created.count, 1, "expected only the output texture to be created")
-  assertSolid(readMipLevel(gl, mipped.texture, 2, 8, 8), [0, 255, 0], "green level 2")
+  assertSolid(readMipLevel(gl, mipped.texture, 2, 16, 16), [0, 255, 0], "green level 2")
   gl.deleteTexture(mipped.texture)
 
   await spark.dispose()
@@ -187,11 +219,11 @@ test("SparkGL: without allocateMipmaps the source texture is reallocated once fo
   gl.deleteTexture(flat.texture)
 
   const created = countTextureCreations(gl)
-  const mipped = await spark.encodeTexture(await makeSolidImage(32, "#00ff00"), { format, generateMipmaps: true })
+  const mipped = await spark.encodeTexture(await makeSolidImage(64, "#00ff00"), { format, generateMipmaps: true })
   assert.equal(created.count, 2, "expected output texture plus one source reallocation")
   gl.deleteTexture(mipped.texture)
 
-  // The reallocated chain is sized for minSize, so a mipmapped 64x64 reuses it.
+  // The reallocated source texture has a mip chain, so another mipmapped 64x64 reuses it.
   const again = await spark.encodeTexture(await makeSolidImage(64, "#0000ff"), { format, generateMipmaps: true })
   assert.equal(created.count, 3, "expected no further reallocation")
   assertSolid(readMipLevel(gl, again.texture, 3, 8, 8), [0, 0, 255], "blue level 3")
@@ -210,4 +242,52 @@ test("SparkGL: invalid minSize is rejected", async () => {
     threw = true
   }
   assert.ok(threw, "expected an error for negative minSize")
+})
+
+const CONSISTENCY_SHAPES = [
+  [1024, 256],
+  [128, 64]
+]
+
+// Encode each shape with mipmaps and decode every level.
+async function encodeAndDecodeAll(gl, spark, images) {
+  const results = []
+  for (const image of images) {
+    const result = await spark.encodeTexture(image, { format: "rgb", generateMipmaps: true })
+    const levels = []
+    for (let level = 0; level < result.mipmapCount; level++) {
+      const w = Math.max(1, image.width >> level)
+      const h = Math.max(1, image.height >> level)
+      levels.push(readMipLevel(gl, result.texture, level, w, h))
+    }
+    gl.deleteTexture(result.texture)
+    results.push(levels)
+  }
+  return results
+}
+
+test("SparkGL: cacheTempResources does not change the encoded result", async () => {
+  const tracker = createGL()
+  const gl = tracker.gl
+  const images = await Promise.all(CONSISTENCY_SHAPES.map(([w, h], i) => makeNoiseImage(w, h, i + 1)))
+
+  const plain = SparkGL.create(gl)
+  const expected = await encodeAndDecodeAll(gl, plain, images)
+  await plain.dispose()
+
+  // Size the cache with a large, contrasting encode first, then encode the test shapes.
+  const cached = SparkGL.create(gl, { cacheTempResources: true })
+  const big = await cached.encodeTexture(await makeSolidImage(1024, "#ff00ff"), { format: "rgb", generateMipmaps: true })
+  gl.deleteTexture(big.texture)
+  const actual = await encodeAndDecodeAll(gl, cached, images)
+  await cached.dispose()
+
+  for (let i = 0; i < images.length; i++) {
+    assert.equal(actual[i].length, expected[i].length, `mip count differs for ${images[i].width}x${images[i].height}`)
+    for (let level = 0; level < expected[i].length; level++) {
+      const diff = firstDifference(actual[i][level], expected[i][level])
+      assert.ok(!diff, `${images[i].width}x${images[i].height} level ${level}: ${diff}`)
+    }
+  }
+  assert.equal(tracker.live.size, 0, `leaked GL resources: ${tracker.describe()}`)
 })

--- a/tests/browser/spark.test.js
+++ b/tests/browser/spark.test.js
@@ -1,5 +1,5 @@
 import { Spark } from "../../src/index.js"
-import { test, assert, skip, makeTestImage, makeSolidImage } from "../harness.js"
+import { test, assert, skip, makeTestImage, makeSolidImage, makeTwoToneImage, makeNoiseImage, firstDifference } from "../harness.js"
 
 async function createDevice() {
   const adapter = await navigator.gpu?.requestAdapter()
@@ -82,8 +82,9 @@ test("Spark: minSize allocates once for a sequence of growing encodes", async ()
       const result = await spark.encodeTexture(await makeTestImage(size, size), { format })
       result.destroy()
     }
-    // One output texture per encode, no cache reallocations.
-    assert.equal(counts.textures, 3, `unexpected texture allocations: ${counts.textures}`)
+    // Per encode: the output texture and the source texture (exact size, so reallocated for
+    // each new size). The output buffer must not be reallocated.
+    assert.equal(counts.textures, 6, `unexpected texture allocations: ${counts.textures}`)
     assert.equal(counts.buffers, 0, `unexpected buffer allocations: ${counts.buffers}`)
     spark.dispose()
   })
@@ -100,7 +101,7 @@ test("Spark: allocateMipmaps avoids reallocation when mipmaps are requested late
     flat.destroy()
 
     const counts = countAllocations(device)
-    const mipped = await spark.encodeTexture(await makeTestImage(32, 32), { format, generateMipmaps: true })
+    const mipped = await spark.encodeTexture(await makeTestImage(64, 64), { format, generateMipmaps: true })
     mipped.destroy()
     assert.equal(counts.textures, 1, `unexpected texture allocations: ${counts.textures}`)
     assert.equal(counts.buffers, 0, `unexpected buffer allocations: ${counts.buffers}`)
@@ -226,3 +227,89 @@ test("Spark: mipsAlphaScale applies a different scale to each mip level", async 
   })
   device.destroy()
 })
+
+function pixelAt(pixels, width, x, y) {
+  const i = (y * width + x) * 4
+  return [pixels[i], pixels[i + 1], pixels[i + 2]]
+}
+
+function assertColor([r, g, b], [er, eg, eb], label, tolerance = 8) {
+  assert.ok(
+    Math.abs(r - er) <= tolerance && Math.abs(g - eg) <= tolerance && Math.abs(b - eb) <= tolerance,
+    `${label}: got (${r}, ${g}, ${b}), expected (${er}, ${eg}, ${eb})`
+  )
+}
+
+test("Spark: cached resources are not reused for a smaller image with flipY", async () => {
+  const device = await createDevice()
+  const spark = await Spark.create(device, { cacheTempResources: true })
+  const format = "rgb"
+
+  await expectNoValidationErrors(device, async () => {
+    // Top half red, bottom half green. flipY goes through the cached tmp texture.
+    const big = await spark.encodeTexture(await makeTwoToneImage(128, "#ff0000", "#00ff00"), { format, flipY: true })
+    big.destroy()
+
+    const small = await spark.encodeTexture(await makeTwoToneImage(64, "#ff0000", "#00ff00"), { format, flipY: true })
+    const pixels = await readTexture(device, small, 64, 64)
+    // Flipped: row 0 of the texture is the bottom (green) half of the image.
+    assertColor(pixelAt(pixels, 64, 0, 0), [0, 255, 0], "top-left")
+    assertColor(pixelAt(pixels, 64, 63, 0), [0, 255, 0], "top-right")
+    assertColor(pixelAt(pixels, 64, 0, 63), [255, 0, 0], "bottom-left")
+    assertColor(pixelAt(pixels, 64, 63, 63), [255, 0, 0], "bottom-right")
+    small.destroy()
+    spark.dispose()
+  })
+  device.destroy()
+})
+
+const CONSISTENCY_SHAPES = [
+  [1024, 256],
+  [128, 64]
+]
+
+// Encode each shape with mipmaps and decode every level.
+async function encodeAndDecodeAll(device, spark, images, options) {
+  const results = []
+  for (const image of images) {
+    const texture = await spark.encodeTexture(image, { format: "rgb", generateMipmaps: true, ...options })
+    const levels = []
+    for (let level = 0; level < texture.mipLevelCount; level++) {
+      const w = Math.max(1, image.width >> level)
+      const h = Math.max(1, image.height >> level)
+      levels.push(await readTexture(device, texture, w, h, level))
+    }
+    texture.destroy()
+    results.push(levels)
+  }
+  return results
+}
+
+for (const mipmapFilter of ["box", "magic"]) {
+  test(`Spark: cacheTempResources does not change the encoded result (${mipmapFilter} filter)`, async () => {
+    const device = await createDevice()
+    const images = await Promise.all(CONSISTENCY_SHAPES.map(([w, h], i) => makeNoiseImage(w, h, i + 1)))
+
+    await expectNoValidationErrors(device, async () => {
+      const plain = await Spark.create(device)
+      const expected = await encodeAndDecodeAll(device, plain, images, { mipmapFilter })
+      plain.dispose()
+
+      // Size the cache with a large, contrasting encode first, then encode the test shapes.
+      const cached = await Spark.create(device, { cacheTempResources: true })
+      const big = await cached.encodeTexture(await makeSolidImage(1024, "#ff00ff"), { format: "rgb", generateMipmaps: true })
+      big.destroy()
+      const actual = await encodeAndDecodeAll(device, cached, images, { mipmapFilter })
+      cached.dispose()
+
+      for (let i = 0; i < images.length; i++) {
+        assert.equal(actual[i].length, expected[i].length, `mip count differs for ${images[i].width}x${images[i].height}`)
+        for (let level = 0; level < expected[i].length; level++) {
+          const diff = firstDifference(actual[i][level], expected[i][level])
+          assert.ok(!diff, `${images[i].width}x${images[i].height} level ${level}: ${diff}`)
+        }
+      }
+    })
+    device.destroy()
+  })
+}

--- a/tests/harness.js
+++ b/tests/harness.js
@@ -96,3 +96,45 @@ export async function makeSolidImage(size, color) {
   ctx.fillRect(0, 0, size, size)
   return createImageBitmap(canvas)
 }
+
+/** An ImageBitmap whose top half is `top` and bottom half is `bottom`. */
+export async function makeTwoToneImage(size, top, bottom) {
+  const canvas = new OffscreenCanvas(size, size)
+  const ctx = canvas.getContext("2d")
+  ctx.fillStyle = top
+  ctx.fillRect(0, 0, size, size / 2)
+  ctx.fillStyle = bottom
+  ctx.fillRect(0, size / 2, size, size / 2)
+  return createImageBitmap(canvas)
+}
+
+/** A deterministic noise ImageBitmap (seeded LCG), so edge/mip differences are visible. */
+export async function makeNoiseImage(width, height, seed = 1) {
+  const canvas = new OffscreenCanvas(width, height)
+  const ctx = canvas.getContext("2d")
+  const data = ctx.createImageData(width, height)
+  let x = seed >>> 0
+  for (let i = 0; i < data.data.length; i += 4) {
+    x = (Math.imul(x, 1664525) + 1013904223) >>> 0
+    data.data[i] = x & 255
+    data.data[i + 1] = (x >>> 8) & 255
+    data.data[i + 2] = (x >>> 16) & 255
+    data.data[i + 3] = 255
+  }
+  ctx.putImageData(data, 0, 0)
+  return createImageBitmap(canvas)
+}
+
+/** Compare two Uint8Arrays; returns null if equal, else a short description of the first difference. */
+export function firstDifference(a, b) {
+  if (a.length !== b.length) return `length ${a.length} vs ${b.length}`
+  let count = 0
+  let first = -1
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      if (first < 0) first = i
+      count++
+    }
+  }
+  return first < 0 ? null : `${count} bytes differ, first at byte ${first} (${a[first]} vs ${b[first]})`
+}


### PR DESCRIPTION
For now this is restricting caching of the source textures to textures of equal size. Otherwise the dimensions mismatch causes pixels from the previous texture to bleed into the new one, as the wrapping mode is only respected at the boundaries of the texture cache.

Fixes issue described here: https://github.com/Ludicon/spark.js/issues/42#issuecomment-5417187433

at the cost of reduced caching efficiency in the general case.

In the future I'd like to look into making the encoders and the mipmap kernels independent of the input texture dimensions.